### PR TITLE
Add basic README

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,9 +21,9 @@ jobs:
           go-version: ${{ matrix.go_version }}
       - name: run tests
         run: go test -coverprofile cov.out ./...
-      - name: report coverage
+      - name: check coverage
         shell: bash
-        run: |
+        run: >
           awk '
           BEGIN {fail = 0}
           NR > 1 && $NF == 0 { fail = 1; printf("bad line: %s\n", $0) }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 - 2023-07-01
+
+Initial release

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# `go-cmark`
+
+![coverage](https://img.shields.io/badge/Coverage-100%25-brightgreen) [![Go
+Reference](https://pkg.go.dev/badge/github.com/matthewhughes934/go-cmark.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark)
+
+Go bindings for [`cmark`](https://github.com/commonmark/cmark) and
+[`cmark-gfm`](https://github.com/github/cmark-gfm)


### PR DESCRIPTION
- Fix some typos in actions config

- Add basic README

    There's a hard-coded link to the coverage badge because I didn't see an
    easy way to serve this from a static URL like GitLab allows, but we
    enforce the coverage level in CI anyway so this seems reasonable

- v0.1.0