### PR TITLE
Add render functions

### DIFF
--- a/pkg/cmark-gfm/cmark_gfm.go
+++ b/pkg/cmark-gfm/cmark_gfm.go
@@ -4,7 +4,7 @@
 package gfm
 
 /*
-#include "cmark.h"
+#include "cmark-gfm.h"
 #include <stdlib.h>
 */
 import "C"

--- a/pkg/cmark-gfm/cmark_gfm.go
+++ b/pkg/cmark-gfm/cmark_gfm.go
@@ -2,3 +2,21 @@
 
 //go:generate ../../scripts/copy-lib ../../cmark-gfm-src
 package gfm
+
+/*
+#include "cmark.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// RenderCommonMark wraps `cmark_render_commonmark`
+// it returns the tree under `root` rendered as a commonmark document
+func RenderCommonMark(root *Node, options ParserOpt, width int) string {
+	cStr := C.cmark_render_commonmark(root.node, C.int(options), C.int(width))
+	defer C.free(unsafe.Pointer(cStr))
+	return C.GoString(cStr)
+}

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -1,0 +1,38 @@
+package gfm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderCommonMark(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		content  string
+		width    int
+		expected string
+	}{
+		"empty in empty out": {"\n", 1, "\n"},
+		"basic document unchanged": {
+			"# My Document\n\nWith a paragraph\n",
+			80,
+			"# My Document\n\nWith a paragraph\n",
+		},
+		"wraps long lines": {
+			strings.Repeat("a", 10)+" "+strings.Repeat("a", 10)+"\n",
+			10,
+			strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10)+"\n",
+		},
+		"basic reformat": {
+			"- a dot point\n",
+			80,
+			"  - a dot point\n",
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			document := ParseDocument(tc.content, ParserOptDefault)
+			require.Equal(t, tc.expected, RenderCommonMark(document, ParserOptDefault, tc.width))
+		})
+	}
+}

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -8,7 +8,6 @@ import "C"
 
 import (
 	"runtime"
-	"unsafe"
 )
 
 // NodeType is cmark_node_type
@@ -63,60 +62,6 @@ const (
 	TypeNoDelim     DelimType = C.CMARK_NO_DELIM
 	TypePeriodDelim DelimType = C.CMARK_PERIOD_DELIM
 	TypeParentDelim DelimType = C.CMARK_PAREN_DELIM
-)
-
-type ParserOpt int
-
-const (
-	// Default options.
-	ParserOptDefault ParserOpt = C.CMARK_OPT_DEFAULT
-
-	// Include a `data-sourcepos` attribute on all block elements.
-	ParserOptSourcePos ParserOpt = C.CMARK_OPT_SOURCEPOS
-
-	// Render `softbreak` elements as hard line breaks.
-	ParserOptHardBreaks ParserOpt = C.CMARK_OPT_HARDBREAKS
-
-	//  Render raw HTML and unsafe links (`javascript:`, `vbscript:`,
-	// `file:`, and `data:`, except for `image/png`, `image/gif`,
-	// `image/jpeg`, or `image/webp` mime types).  By default,
-	// raw HTML is replaced by a placeholder HTML comment. Unsafe
-	// links are replaced by empty strings.
-	ParserOptUnsafe ParserOpt = C.CMARK_OPT_UNSAFE
-
-	// Render `softbreak` elements as spaces.
-	ParserOptNoBreaks ParserOpt = C.CMARK_OPT_NOBREAKS
-
-	// Legacy option (no effect).
-	ParserOptNormalize ParserOpt = C.CMARK_OPT_NORMALIZE
-
-	//  Validate UTF-8 in the input before parsing, replacing illegal
-	// sequences with the replacement character U+FFFD.
-	ParserOptValidateUTF8 ParserOpt = C.CMARK_OPT_VALIDATE_UTF8
-
-	// Convert straight quotes to curly, --- to em dashes, -- to en dashes.
-	ParserOptSmart ParserOpt = C.CMARK_OPT_SMART
-
-	// Use GitHub-style <pre lang="x"> tags for code blocks instead of <pre><code
-	// class="language-x">.
-	ParserOptGithubPreLang = C.CMARK_OPT_GITHUB_PRE_LANG
-
-	// Be liberal in interpreting inline HTML tags.
-	ParserOptLiberalHTMLTag = C.CMARK_OPT_LIBERAL_HTML_TAG
-
-	// Parse footnotes.
-	ParserOptFootnotes = C.CMARK_OPT_FOOTNOTES
-
-	// Only parse strikethroughs if surrounded by exactly 2 tildes.
-	// Gives some compatibility with redcarpet.
-	ParserOptStrikethroughDoubleTilde = C.CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE
-
-	// Use style attributes to align table cells instead of align attributes.
-	ParserOptTablePreferStyleAttributes = C.CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES
-
-	// Include the remainder of the info string in code blocks in
-	// a separate attribute.
-	ParserOptFullInfoString = C.CMARK_OPT_FULL_INFO_STRING
 )
 
 type Node struct {
@@ -290,21 +235,4 @@ func (node *Node) LastChild() *Node {
 	}
 
 	return &Node{node: lastChild}
-}
-
-// ParseDocument wraps cmark_parse_document
-// Parse a CommonMark document in 'document' and returns a pointer to a tree of nodes.
-// The returned [cmark.Node] has a finalizer set that will call
-// `cmark_node_free` which will free the memory allocated for the node and any
-// of its children
-func ParseDocument(document string, options ParserOpt) *Node {
-	str := C.CString(document)
-	defer C.free(unsafe.Pointer(str))
-
-	node := &Node{
-		node: C.cmark_parse_document(str, C.size_t(len(document)), C.int(options)),
-	}
-	runtime.SetFinalizer(node, (*Node).free)
-
-	return node
 }

--- a/pkg/cmark-gfm/parser.go
+++ b/pkg/cmark-gfm/parser.go
@@ -11,6 +11,61 @@ import (
 	"unsafe"
 )
 
+type ParserOpt int
+
+const (
+	// Default options.
+	ParserOptDefault ParserOpt = C.CMARK_OPT_DEFAULT
+
+	// Include a `data-sourcepos` attribute on all block elements.
+	ParserOptSourcePos ParserOpt = C.CMARK_OPT_SOURCEPOS
+
+	// Render `softbreak` elements as hard line breaks.
+	ParserOptHardBreaks ParserOpt = C.CMARK_OPT_HARDBREAKS
+
+	//  Render raw HTML and unsafe links (`javascript:`, `vbscript:`,
+	// `file:`, and `data:`, except for `image/png`, `image/gif`,
+	// `image/jpeg`, or `image/webp` mime types).  By default,
+	// raw HTML is replaced by a placeholder HTML comment. Unsafe
+	// links are replaced by empty strings.
+	ParserOptUnsafe ParserOpt = C.CMARK_OPT_UNSAFE
+
+	// Render `softbreak` elements as spaces.
+	ParserOptNoBreaks ParserOpt = C.CMARK_OPT_NOBREAKS
+
+	// Legacy option (no effect).
+	ParserOptNormalize ParserOpt = C.CMARK_OPT_NORMALIZE
+
+	//  Validate UTF-8 in the input before parsing, replacing illegal
+	// sequences with the replacement character U+FFFD.
+	ParserOptValidateUTF8 ParserOpt = C.CMARK_OPT_VALIDATE_UTF8
+
+	// Convert straight quotes to curly, --- to em dashes, -- to en dashes.
+	ParserOptSmart ParserOpt = C.CMARK_OPT_SMART
+
+	// Use GitHub-style <pre lang="x"> tags for code blocks instead of <pre><code
+	// class="language-x">.
+	ParserOptGithubPreLang = C.CMARK_OPT_GITHUB_PRE_LANG
+
+	// Be liberal in interpreting inline HTML tags.
+	ParserOptLiberalHTMLTag = C.CMARK_OPT_LIBERAL_HTML_TAG
+
+	// Parse footnotes.
+	ParserOptFootnotes = C.CMARK_OPT_FOOTNOTES
+
+	// Only parse strikethroughs if surrounded by exactly 2 tildes.
+	// Gives some compatibility with redcarpet.
+	ParserOptStrikethroughDoubleTilde = C.CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE
+
+	// Use style attributes to align table cells instead of align attributes.
+	ParserOptTablePreferStyleAttributes = C.CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES
+
+	// Include the remainder of the info string in code blocks in
+	// a separate attribute.
+	ParserOptFullInfoString = C.CMARK_OPT_FULL_INFO_STRING
+)
+
+
 type Parser struct {
 	parser *C.cmark_parser
 }
@@ -44,4 +99,21 @@ func (parser *Parser) Finish() *Node {
 	return &Node{
 		node: C.cmark_parser_finish(parser.parser),
 	}
+}
+
+// ParseDocument wraps cmark_parse_document
+// Parse a CommonMark document in 'document' and returns a pointer to a tree of nodes.
+// The returned [cmark.Node] has a finalizer set that will call
+// `cmark_node_free` which will free the memory allocated for the node and any
+// of its children
+func ParseDocument(document string, options ParserOpt) *Node {
+	str := C.CString(document)
+	defer C.free(unsafe.Pointer(str))
+
+	node := &Node{
+		node: C.cmark_parse_document(str, C.size_t(len(document)), C.int(options)),
+	}
+	runtime.SetFinalizer(node, (*Node).free)
+
+	return node
 }

--- a/pkg/cmark/cmark.go
+++ b/pkg/cmark/cmark.go
@@ -2,3 +2,21 @@
 
 //go:generate ../../scripts/copy-lib ../../cmark-src
 package cmark
+
+/*
+#include "cmark.h"
+#include <stdlib.h>
+*/
+import "C"
+
+import (
+	"unsafe"
+)
+
+// RenderCommonMark wraps `cmark_render_commonmark`
+// it returns the tree under `root` rendered as a commonmark document
+func RenderCommonMark(root *Node, options ParserOpt, width int) string {
+	cStr := C.cmark_render_commonmark(root.node, C.int(options), C.int(width))
+	defer C.free(unsafe.Pointer(cStr))
+	return C.GoString(cStr)
+}

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -1,0 +1,38 @@
+package cmark
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderCommonMark(t *testing.T) {
+	for desc, tc := range map[string]struct {
+		content  string
+		width    int
+		expected string
+	}{
+		"empty in empty out": {"\n", 1, "\n"},
+		"basic document unchanged": {
+			"# My Document\n\nWith a paragraph\n",
+			80,
+			"# My Document\n\nWith a paragraph\n",
+		},
+		"wraps long lines": {
+			strings.Repeat("a", 10)+" "+strings.Repeat("a", 10)+"\n",
+			10,
+			strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10)+"\n",
+		},
+		"basic reformat": {
+			"- a dot point\n",
+			80,
+			"  - a dot point\n",
+		},
+	} {
+		t.Run(desc, func(t *testing.T) {
+			document := ParseDocument(tc.content, ParserOptDefault)
+			require.Equal(t, tc.expected, RenderCommonMark(document, ParserOptDefault, tc.width))
+		})
+	}
+}

--- a/pkg/cmark/node.go
+++ b/pkg/cmark/node.go
@@ -8,7 +8,6 @@ import "C"
 
 import (
 	"runtime"
-	"unsafe"
 )
 
 // NodeType is cmark_node_type
@@ -65,39 +64,6 @@ const (
 	TypeNoDelim     DelimType = C.CMARK_NO_DELIM
 	TypePeriodDelim DelimType = C.CMARK_PERIOD_DELIM
 	TypeParentDelim DelimType = C.CMARK_PAREN_DELIM
-)
-
-type ParserOpt int
-
-const (
-	// Default options.
-	ParserOptDefault ParserOpt = C.CMARK_OPT_DEFAULT
-
-	// Include a `data-sourcepos` attribute on all block elements.
-	ParserOptSourcePos ParserOpt = C.CMARK_OPT_SOURCEPOS
-
-	// Render `softbreak` elements as hard line breaks.
-	ParserOptHardBreaks ParserOpt = C.CMARK_OPT_HARDBREAKS
-
-	//  Render raw HTML and unsafe links (`javascript:`, `vbscript:`,
-	// `file:`, and `data:`, except for `image/png`, `image/gif`,
-	// `image/jpeg`, or `image/webp` mime types).  By default,
-	// raw HTML is replaced by a placeholder HTML comment. Unsafe
-	// links are replaced by empty strings.
-	ParserOptUnsafe ParserOpt = C.CMARK_OPT_UNSAFE
-
-	// Render `softbreak` elements as spaces.
-	ParserOptNoBreaks ParserOpt = C.CMARK_OPT_NOBREAKS
-
-	// Legacy option (no effect).
-	ParserOptNormalize ParserOpt = C.CMARK_OPT_NORMALIZE
-
-	//  Validate UTF-8 in the input before parsing, replacing illegal
-	// sequences with the replacement character U+FFFD.
-	ParserOptValidateUTF8 ParserOpt = C.CMARK_OPT_VALIDATE_UTF8
-
-	// Convert straight quotes to curly, --- to em dashes, -- to en dashes.
-	ParserOptSmart ParserOpt = C.CMARK_OPT_SMART
 )
 
 type Node struct {
@@ -271,21 +237,4 @@ func (node *Node) LastChild() *Node {
 	}
 
 	return &Node{node: lastChild}
-}
-
-// ParseDocument wraps cmark_parse_document
-// Parse a CommonMark document in 'document' and returns a pointer to a tree of nodes.
-// The returned [cmark.Node] has a finalizer set that will call
-// `cmark_node_free` which will free the memory allocated for the node and any
-// of its children
-func ParseDocument(document string, options ParserOpt) *Node {
-	str := C.CString(document)
-	defer C.free(unsafe.Pointer(str))
-
-	node := &Node{
-		node: C.cmark_parse_document(str, C.size_t(len(document)), C.int(options)),
-	}
-	runtime.SetFinalizer(node, (*Node).free)
-
-	return node
 }

--- a/pkg/cmark/parser.go
+++ b/pkg/cmark/parser.go
@@ -15,6 +15,40 @@ type Parser struct {
 	parser *C.cmark_parser
 }
 
+type ParserOpt int
+
+const (
+	// Default options.
+	ParserOptDefault ParserOpt = C.CMARK_OPT_DEFAULT
+
+	// Include a `data-sourcepos` attribute on all block elements.
+	ParserOptSourcePos ParserOpt = C.CMARK_OPT_SOURCEPOS
+
+	// Render `softbreak` elements as hard line breaks.
+	ParserOptHardBreaks ParserOpt = C.CMARK_OPT_HARDBREAKS
+
+	//  Render raw HTML and unsafe links (`javascript:`, `vbscript:`,
+	// `file:`, and `data:`, except for `image/png`, `image/gif`,
+	// `image/jpeg`, or `image/webp` mime types).  By default,
+	// raw HTML is replaced by a placeholder HTML comment. Unsafe
+	// links are replaced by empty strings.
+	ParserOptUnsafe ParserOpt = C.CMARK_OPT_UNSAFE
+
+	// Render `softbreak` elements as spaces.
+	ParserOptNoBreaks ParserOpt = C.CMARK_OPT_NOBREAKS
+
+	// Legacy option (no effect).
+	ParserOptNormalize ParserOpt = C.CMARK_OPT_NORMALIZE
+
+	//  Validate UTF-8 in the input before parsing, replacing illegal
+	// sequences with the replacement character U+FFFD.
+	ParserOptValidateUTF8 ParserOpt = C.CMARK_OPT_VALIDATE_UTF8
+
+	// Convert straight quotes to curly, --- to em dashes, -- to en dashes.
+	ParserOptSmart ParserOpt = C.CMARK_OPT_SMART
+)
+
+
 // free wraps cmark_parser_free
 func (parser *Parser) free() { //go-cov:skip
 	C.cmark_parser_free(parser.parser)
@@ -44,4 +78,21 @@ func (parser *Parser) Finish() *Node {
 	return &Node{
 		node: C.cmark_parser_finish(parser.parser),
 	}
+}
+
+// ParseDocument wraps cmark_parse_document
+// Parse a CommonMark document in 'document' and returns a pointer to a tree of nodes.
+// The returned [cmark.Node] has a finalizer set that will call
+// `cmark_node_free` which will free the memory allocated for the node and any
+// of its children
+func ParseDocument(document string, options ParserOpt) *Node {
+	str := C.CString(document)
+	defer C.free(unsafe.Pointer(str))
+
+	node := &Node{
+		node: C.cmark_parse_document(str, C.size_t(len(document)), C.int(options)),
+	}
+	runtime.SetFinalizer(node, (*Node).free)
+
+	return node
 }


### PR DESCRIPTION
- Extract some parser code from `node.go`

- Add wrapper for `cmark_render_commonmark`

    Add a wrapper in both `cmark` and `cmark-gfm`.