### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `go-cmark`
 
-![coverage](https://img.shields.io/badge/Coverage-100%25-brightgreen) [![Go
+[![coverage](https://img.shields.io/badge/Coverage-100%25-brightgreen)](https://github.com/matthewhughes934/go-cmark)
+[![Go
 Reference](https://pkg.go.dev/badge/github.com/matthewhughes934/go-cmark.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark)
 
 Go bindings for [`cmark`](https://github.com/commonmark/cmark) and

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -20,9 +20,9 @@ func TestRenderCommonMark(t *testing.T) {
 			"# My Document\n\nWith a paragraph\n",
 		},
 		"wraps long lines": {
-			strings.Repeat("a", 10)+" "+strings.Repeat("a", 10)+"\n",
+			strings.Repeat("a", 10) + " " + strings.Repeat("a", 10) + "\n",
 			10,
-			strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10)+"\n",
+			strings.Repeat("a", 10) + "\n" + strings.Repeat("a", 10) + "\n",
 		},
 		"basic reformat": {
 			"- a dot point\n",

--- a/pkg/cmark-gfm/iterator.go
+++ b/pkg/cmark-gfm/iterator.go
@@ -18,6 +18,36 @@ const (
 	EventTypeExit  EventType = C.CMARK_EVENT_EXIT
 )
 
+/*
+Iter wraps cmark_iter
+
+An iterator will walk through a tree of nodes, starting from a root node,
+returning one node at a time, together with information about whether the node
+is being entered or exited. The iterator will first descend to a child node, if
+there is one. When there is no child, the iterator will go to the next sibling.
+When there is no next sibling, the iterator will return to the parent (but with
+a [EventType] of [EventTypeExit]). The iterator will return [EventTypeDone]
+when it reaches the root node again.  One natural application is an HTML
+renderer, where an [EventTypeEnter] event outputs an open tag and an
+[EventTypeExit] event outputs a close tag. An iterator might also be used to
+transform an AST in some systematic way, for example, turning all level-3
+headings into regular paragraphs.
+
+Iterators will never return [EventTypeExit] events for leaf noes, which are
+nodes of type:
+
+	* [NodeTypeHTMLBlock]
+	* [NodeTypeThematicBreak]
+	* [NodeTypeCodeBlock]
+	* [NodeTypeText]
+	* [NodeTypeSoftbreak]
+	* [NodeTypeLinebreak]
+	* [NodeTypeCode]
+	* [NodeTypeHTMLInline]
+
+Nodes must only be modified after an [EvenTypeExit] event or an
+[EventTypeEnter] for leaf nodes
+*/
 type Iter struct {
 	iter *C.cmark_iter
 }

--- a/pkg/cmark-gfm/iterator_test.go
+++ b/pkg/cmark-gfm/iterator_test.go
@@ -1,6 +1,7 @@
 package gfm
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,4 +49,35 @@ func TestIterAPI(t *testing.T) {
 	require.Equal(t, EventTypeDone, iter.Next())
 
 	require.Equal(t, iter.GetRoot(), rootNode)
+}
+
+func ExampleIter() {
+	root := ParseDocument("# Document\n\nsome text\n", ParserOptDefault)
+	iter := NewIter(root)
+
+	evType := iter.Next()
+	for ; evType != EventTypeDone; evType = iter.Next() {
+		cur := iter.GetNode()
+		fmt.Print(cur.GetTypeString())
+		switch evType {
+		case EventTypeNone:
+			fmt.Println(" NONE")
+		case EventTypeDone:
+			fmt.Println(" DONE")
+		case EventTypeEnter:
+			fmt.Println(" ENTER")
+		case EventTypeExit:
+			fmt.Println(" EXIT")
+		}
+	}
+
+	// Output:
+	// document ENTER
+	// heading ENTER
+	// text ENTER
+	// heading EXIT
+	// paragraph ENTER
+	// text ENTER
+	// paragraph EXIT
+	// document EXIT
 }

--- a/pkg/cmark-gfm/parser.go
+++ b/pkg/cmark-gfm/parser.go
@@ -65,7 +65,6 @@ const (
 	ParserOptFullInfoString = C.CMARK_OPT_FULL_INFO_STRING
 )
 
-
 type Parser struct {
 	parser *C.cmark_parser
 }

--- a/pkg/cmark/iterator.go
+++ b/pkg/cmark/iterator.go
@@ -18,6 +18,36 @@ const (
 	EventTypeExit  EventType = C.CMARK_EVENT_EXIT
 )
 
+/*
+Iter wraps cmark_iter
+
+An iterator will walk through a tree of nodes, starting from a root node,
+returning one node at a time, together with information about whether the node
+is being entered or exited. The iterator will first descend to a child node, if
+there is one. When there is no child, the iterator will go to the next sibling.
+When there is no next sibling, the iterator will return to the parent (but with
+a [EventType] of [EventTypeExit]). The iterator will return [EventTypeDone]
+when it reaches the root node again.  One natural application is an HTML
+renderer, where an [EventTypeEnter] event outputs an open tag and an
+[EventTypeExit] event outputs a close tag. An iterator might also be used to
+transform an AST in some systematic way, for example, turning all level-3
+headings into regular paragraphs.
+
+Iterators will never return [EventTypeExit] events for leaf noes, which are
+nodes of type:
+
+	* [NodeTypeHTMLBlock]
+	* [NodeTypeThematicBreak]
+	* [NodeTypeCodeBlock]
+	* [NodeTypeText]
+	* [NodeTypeSoftbreak]
+	* [NodeTypeLinebreak]
+	* [NodeTypeCode]
+	* [NodeTypeHTMLInline]
+
+Nodes must only be modified after an [EvenTypeExit] event or an
+[EventTypeEnter] for leaf nodes
+*/
 type Iter struct {
 	iter *C.cmark_iter
 }

--- a/pkg/cmark/iterator_test.go
+++ b/pkg/cmark/iterator_test.go
@@ -1,6 +1,7 @@
 package cmark
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -48,4 +49,35 @@ func TestIterAPI(t *testing.T) {
 	require.Equal(t, EventTypeDone, iter.Next())
 
 	require.Equal(t, iter.GetRoot(), rootNode)
+}
+
+func ExampleIter() {
+	root := ParseDocument("# Document\n\nsome text\n", ParserOptDefault)
+	iter := NewIter(root)
+
+	evType := iter.Next()
+	for ; evType != EventTypeDone; evType = iter.Next() {
+		cur := iter.GetNode()
+		fmt.Print(cur.GetTypeString())
+		switch evType {
+		case EventTypeNone:
+			fmt.Println(" NONE")
+		case EventTypeDone:
+			fmt.Println(" DONE")
+		case EventTypeEnter:
+			fmt.Println(" ENTER")
+		case EventTypeExit:
+			fmt.Println(" EXIT")
+		}
+	}
+
+	// Output:
+	// document ENTER
+	// heading ENTER
+	// text ENTER
+	// heading EXIT
+	// paragraph ENTER
+	// text ENTER
+	// paragraph EXIT
+	// document EXIT
 }

--- a/scripts/copy-lib
+++ b/scripts/copy-lib
@@ -18,7 +18,7 @@ pushd "$submodule_path"
 # this is a hack!
 # we need the generated files e.g. config.h in the same dir
 # as the .go files for cgo to compile it. But this requires
-# generating this file now. Admittedly there's no much generated her
+# generating this file now. Admittedly there's no much generated here
 # so maybe not a big problem
 make build
 popd


### PR DESCRIPTION
- Fix typo in script comment

- Fix linking for coverage badge

    Just link back to this repo rather than not including a link

- Copy docs for iterator

    Copy the C docs to go, include an example

- Tidy some formatting

    i.e. result of `golangci-lint run --fix`. It's probably worth
    investigating why this doesn't cause an error when running
    `golangci-lint run`