### PR TITLE
Add more getters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   tests: true
   skip-dirs:
-    - cmark
+    - "^cmark-.*-src"
 
 linters-settings:
   errcheck:

--- a/cmd/cmark-go/main.go
+++ b/cmd/cmark-go/main.go
@@ -14,9 +14,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/urfave/cli/v3"
-
 	"github.com/matthewhughes934/go-cmark/pkg/cmark"
+	"github.com/urfave/cli/v3"
 )
 
 func main() { //go-cov:skip

--- a/pkg/cmark-gfm/iterator.go
+++ b/pkg/cmark-gfm/iterator.go
@@ -36,14 +36,14 @@ headings into regular paragraphs.
 Iterators will never return [EventTypeExit] events for leaf noes, which are
 nodes of type:
 
-	* [NodeTypeHTMLBlock]
-	* [NodeTypeThematicBreak]
-	* [NodeTypeCodeBlock]
-	* [NodeTypeText]
-	* [NodeTypeSoftbreak]
-	* [NodeTypeLinebreak]
-	* [NodeTypeCode]
-	* [NodeTypeHTMLInline]
+  - [NodeTypeHTMLBlock]
+  - [NodeTypeThematicBreak]
+  - [NodeTypeCodeBlock]
+  - [NodeTypeText]
+  - [NodeTypeSoftbreak]
+  - [NodeTypeLinebreak]
+  - [NodeTypeCode]
+  - [NodeTypeHTMLInline]
 
 Nodes must only be modified after an [EvenTypeExit] event or an
 [EventTypeEnter] for leaf nodes

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -126,6 +126,13 @@ func (node *Node) IsTightList() bool {
 	return C.cmark_node_get_list_tight(node.node) == C.int(1)
 }
 
+// GetFenceInfo wraps cmark_node_get_fence_info
+// Returns the info string from a fenced code block. Returns nil if called on a
+// node that is not a code block
+func (node *Node) GetFenceInfo() *string {
+	return stringOrNil(C.cmark_node_get_fence_info(node.node))
+}
+
 // GetUrl wraps cmark_node_get_url
 // Returns the URL of a link or image 'node', or an empty string
 // if no URL is set.  Returns NULL if called on a node that is

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -98,13 +98,7 @@ func (node *Node) GetTypeString() string {
 // string if none is set. Returns nil if called on a
 // node that does not have string content.
 func (node *Node) GetLiteral() *string {
-	literal := C.cmark_node_get_literal(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_literal(node.node))
 }
 
 // GetHeadingLevel wraps cmark_node_get_heading_level
@@ -137,13 +131,7 @@ func (node *Node) IsTightList() bool {
 // if no URL is set.  Returns NULL if called on a node that is
 // not a link or image.
 func (node *Node) GetUrl() *string {
-	literal := C.cmark_node_get_url(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_url(node.node))
 }
 
 // GetTitle wraps cmark_node_get_title
@@ -151,13 +139,7 @@ func (node *Node) GetUrl() *string {
 // if no URL is set. Returns nil if called on a node that is not a
 // link or image
 func (node *Node) GetTitle() *string {
-	literal := C.cmark_node_get_title(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_title(node.node))
 }
 
 // GetStartLine wraps cmark_node_get_start_line
@@ -188,51 +170,53 @@ func (node *Node) GetEndColumn() int {
 // Returns the next node in the sequence after 'node', or nil if
 // there is none
 func (node *Node) Next() *Node {
-	next := C.cmark_node_next(node.node)
-	if next == nil {
-		return nil
-	}
-	return &Node{node: next}
+	return nodeOrNil(C.cmark_node_next(node.node))
 }
 
 // Previous wraps cmark_node_previous
 // Returns the previous node in the sequence after 'node', or none if
 // there is none
 func (node *Node) Previous() *Node {
-	previous := C.cmark_node_previous(node.node)
-	if previous == nil {
-		return nil
-	}
-	return &Node{node: previous}
+	return nodeOrNil(C.cmark_node_previous(node.node))
 }
 
 // Parent wraps cmark_node_parent
 // Returns the parent of 'node', or nil if there is none.
 func (node *Node) Parent() *Node {
-	parent := C.cmark_node_parent(node.node)
-	if parent == nil {
-		return nil
-	}
-	return &Node{node: parent}
+	return nodeOrNil(C.cmark_node_parent(node.node))
 }
 
 // FirstChild wraps cmark_node_first_child
 // Returns the first child of 'node', or nil if 'node' has no children.
 func (node *Node) FirstChild() *Node {
-	firstChild := C.cmark_node_first_child(node.node)
-	if firstChild == nil {
-		return nil
-	}
-	return &Node{node: firstChild}
+	return nodeOrNil(C.cmark_node_first_child(node.node))
 }
 
 // LastChild wraps cmark_node_last_child
 // Returns the last child of 'node', or nil if 'node' has no children.
 func (node *Node) LastChild() *Node {
-	lastChild := C.cmark_node_last_child(node.node)
-	if lastChild == nil {
+	return nodeOrNil(C.cmark_node_last_child(node.node))
+}
+
+// some cmark functions like `cmark_node_get_url` reutrn a `char *` that will
+// be `NULL` if the relevant data can't be fetch (e.g. if the node doesn't
+// actually contain a URL) this preserves that behaviour
+// this could probably be somewhere shared, but https://github.com/golang/go/issues/13467
+func stringOrNil(s *C.char) *string {
+	if s == nil {
 		return nil
 	}
 
-	return &Node{node: lastChild}
+	str := C.GoString(s)
+	return &str
+}
+
+// similar to above, though can't share because there's no single definition of
+// 'C.cmark_node' between the two libs
+func nodeOrNil(n *C.cmark_node) *Node {
+	if n == nil {
+		return nil
+	}
+
+	return &Node{node: n}
 }

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -18,16 +18,17 @@ const (
 	NodeTypeNone NodeType = C.CMARK_NODE_NONE
 
 	/* Block */
-	NodeTypeDocument      NodeType = C.CMARK_NODE_DOCUMENT
-	NodeTypeBlockQuote    NodeType = C.CMARK_NODE_BLOCK_QUOTE
-	NodeTypeList          NodeType = C.CMARK_NODE_LIST
-	NodeTypeItem          NodeType = C.CMARK_NODE_ITEM
-	NodeTypeCodeBlock     NodeType = C.CMARK_NODE_CODE_BLOCK
-	NodeTypeHTMLBlock     NodeType = C.CMARK_NODE_HTML_BLOCK
-	NodeTypeCustomBlock   NodeType = C.CMARK_NODE_CUSTOM_BLOCK
-	NodeTypeParagraph     NodeType = C.CMARK_NODE_PARAGRAPH
-	NodeTypeHeading       NodeType = C.CMARK_NODE_HEADING
-	NodeTypeThematicBreak NodeType = C.CMARK_NODE_THEMATIC_BREAK
+	NodeTypeDocument           NodeType = C.CMARK_NODE_DOCUMENT
+	NodeTypeBlockQuote         NodeType = C.CMARK_NODE_BLOCK_QUOTE
+	NodeTypeList               NodeType = C.CMARK_NODE_LIST
+	NodeTypeItem               NodeType = C.CMARK_NODE_ITEM
+	NodeTypeCodeBlock          NodeType = C.CMARK_NODE_CODE_BLOCK
+	NodeTypeHTMLBlock          NodeType = C.CMARK_NODE_HTML_BLOCK
+	NodeTypeCustomBlock        NodeType = C.CMARK_NODE_CUSTOM_BLOCK
+	NodeTypeParagraph          NodeType = C.CMARK_NODE_PARAGRAPH
+	NodeTypeHeading            NodeType = C.CMARK_NODE_HEADING
+	NodeTypeThematicBreak      NodeType = C.CMARK_NODE_THEMATIC_BREAK
+	NoteTypeFootnoteDefinition NodeType = C.CMARK_NODE_FOOTNOTE_DEFINITION
 
 	NodeTypeFirstBlock NodeType = C.CMARK_NODE_DOCUMENT
 	NodeTypeLastBlock  NodeType = C.CMARK_NODE_THEMATIC_BREAK
@@ -203,6 +204,13 @@ func (node *Node) FirstChild() *Node {
 // Returns the last child of 'node', or nil if 'node' has no children.
 func (node *Node) LastChild() *Node {
 	return nodeOrNil(C.cmark_node_last_child(node.node))
+}
+
+// ParentFootnoteDef wraps cmark_node_parent_footnote_def
+// Returns the footnote reference of 'node', or NULL if 'node' doesn't have a
+// footnote reference
+func (node *Node) ParentFootnoteDef() *Node {
+	return nodeOrNil(C.cmark_node_parent_footnote_def(node.node))
 }
 
 // some cmark functions like `cmark_node_get_url` reutrn a `char *` that will

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -43,7 +43,7 @@ const (
 	NodeTypeStrong            NodeType = C.CMARK_NODE_STRONG
 	NodeTypeLink              NodeType = C.CMARK_NODE_LINK
 	NodeTypeImage             NodeType = C.CMARK_NODE_IMAGE
-	NodeTypeFootNoteReference NodeType = C.CMARK_NODE_FOOTNOTE_REFERENCE
+	NodeTypeFootnoteReference NodeType = C.CMARK_NODE_FOOTNOTE_REFERENCE
 )
 
 // ListType is cmark_list_type

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -104,6 +104,18 @@ func TestLastChild(t *testing.T) {
 	require.Equal(t, NodeTypeParagraph, lastChild.GetType())
 }
 
+func TestParentFootnoteDef(t *testing.T) {
+	document := ParseDocument("Here's a simple footnote[^1]\n\n[^1]: My Reference\n", ParserOptDefault|ParserOptFootnotes)
+
+	// document->paragraph->text->footnote
+	footnoteRef := document.FirstChild().FirstChild().Next()
+	// document->(2nd)paragraph->footnote
+	footnoteDef := document.FirstChild().Next().FirstChild()
+
+	require.Nil(t, footnoteDef.ParentFootnoteDef())
+	require.Equal(t, footnoteRef.ParentFootnoteDef(), footnoteDef)
+}
+
 func TestNodeNextNoNext(t *testing.T) {
 	document := ParseDocument("", ParserOptDefault)
 	require.NotNil(t, document)

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -256,10 +256,10 @@ func TestGetFenceInfoNoInfo(t *testing.T) {
 }
 
 func TestGetFenceInfo(t *testing.T) {
-	for _, tc := range []struct{
-		content string
+	for _, tc := range []struct {
+		content  string
 		expected string
-	} {
+	}{
 		{"```bash\necho 'hello'\n```\n", "bash"},
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -246,6 +246,32 @@ func TestIsTightList(t *testing.T) {
 	}
 }
 
+func TestGetFenceInfoNoInfo(t *testing.T) {
+	document := ParseDocument("No code fence\n", ParserOptDefault)
+
+	content := document.FirstChild()
+	require.NotNil(t, content)
+
+	require.Nil(t, content.GetFenceInfo())
+}
+
+func TestGetFenceInfo(t *testing.T) {
+	for _, tc := range []struct{
+		content string
+		expected string
+	} {
+		{"```bash\necho 'hello'\n```\n", "bash"},
+		{"~~~python\nprint('hello')\n~~~\n", "python"},
+	} {
+		t.Run(tc.content, func(t *testing.T) {
+			document := ParseDocument(tc.content, ParserOptDefault)
+			fenceNode := document.FirstChild()
+
+			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
+		})
+	}
+}
+
 func TestGetUrlNoUrl(t *testing.T) {
 	document := ParseDocument("No URL here\n", ParserOptDefault)
 

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -20,9 +20,9 @@ func TestRenderCommonMark(t *testing.T) {
 			"# My Document\n\nWith a paragraph\n",
 		},
 		"wraps long lines": {
-			strings.Repeat("a", 10)+" "+strings.Repeat("a", 10)+"\n",
+			strings.Repeat("a", 10) + " " + strings.Repeat("a", 10) + "\n",
 			10,
-			strings.Repeat("a", 10)+"\n"+strings.Repeat("a", 10)+"\n",
+			strings.Repeat("a", 10) + "\n" + strings.Repeat("a", 10) + "\n",
 		},
 		"basic reformat": {
 			"- a dot point\n",

--- a/pkg/cmark/iterator.go
+++ b/pkg/cmark/iterator.go
@@ -36,14 +36,14 @@ headings into regular paragraphs.
 Iterators will never return [EventTypeExit] events for leaf noes, which are
 nodes of type:
 
-	* [NodeTypeHTMLBlock]
-	* [NodeTypeThematicBreak]
-	* [NodeTypeCodeBlock]
-	* [NodeTypeText]
-	* [NodeTypeSoftbreak]
-	* [NodeTypeLinebreak]
-	* [NodeTypeCode]
-	* [NodeTypeHTMLInline]
+  - [NodeTypeHTMLBlock]
+  - [NodeTypeThematicBreak]
+  - [NodeTypeCodeBlock]
+  - [NodeTypeText]
+  - [NodeTypeSoftbreak]
+  - [NodeTypeLinebreak]
+  - [NodeTypeCode]
+  - [NodeTypeHTMLInline]
 
 Nodes must only be modified after an [EvenTypeExit] event or an
 [EventTypeEnter] for leaf nodes

--- a/pkg/cmark/node.go
+++ b/pkg/cmark/node.go
@@ -128,6 +128,13 @@ func (node *Node) IsTightList() bool {
 	return C.cmark_node_get_list_tight(node.node) == C.int(1)
 }
 
+// GetFenceInfo wraps cmark_node_get_fence_info
+// Returns the info string from a fenced code block. Returns nil if called on a
+// node that is not a code block
+func (node *Node) GetFenceInfo() *string {
+	return stringOrNil(C.cmark_node_get_fence_info(node.node))
+}
+
 // GetUrl wraps cmark_node_get_url
 // Returns the URL of a link or image 'node', or an empty string
 // if no URL is set.  Returns NULL if called on a node that is

--- a/pkg/cmark/node.go
+++ b/pkg/cmark/node.go
@@ -100,13 +100,7 @@ func (node *Node) GetTypeString() string {
 // string if none is set. Returns nil if called on a
 // node that does not have string content.
 func (node *Node) GetLiteral() *string {
-	literal := C.cmark_node_get_literal(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_literal(node.node))
 }
 
 // GetHeadingLevel wraps cmark_node_get_heading_level
@@ -139,13 +133,7 @@ func (node *Node) IsTightList() bool {
 // if no URL is set.  Returns NULL if called on a node that is
 // not a link or image.
 func (node *Node) GetUrl() *string {
-	literal := C.cmark_node_get_url(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_url(node.node))
 }
 
 // GetTitle wraps cmark_node_get_title
@@ -153,13 +141,7 @@ func (node *Node) GetUrl() *string {
 // if no URL is set. Returns nil if called on a node that is not a
 // link or image
 func (node *Node) GetTitle() *string {
-	literal := C.cmark_node_get_title(node.node)
-	if literal == nil {
-		return nil
-	}
-
-	str := C.GoString(literal)
-	return &str
+	return stringOrNil(C.cmark_node_get_title(node.node))
 }
 
 // GetStartLine wraps cmark_node_get_start_line
@@ -190,51 +172,51 @@ func (node *Node) GetEndColumn() int {
 // Returns the next node in the sequence after 'node', or nil if
 // there is none
 func (node *Node) Next() *Node {
-	next := C.cmark_node_next(node.node)
-	if next == nil {
-		return nil
-	}
-	return &Node{node: next}
+	return nodeOrNil(C.cmark_node_next(node.node))
 }
 
 // Previous wraps cmark_node_previous
 // Returns the previous node in the sequence after 'node', or none if
 // there is none
 func (node *Node) Previous() *Node {
-	previous := C.cmark_node_previous(node.node)
-	if previous == nil {
-		return nil
-	}
-	return &Node{node: previous}
+	return nodeOrNil(C.cmark_node_previous(node.node))
 }
 
 // Parent wraps cmark_node_parent
 // Returns the parent of 'node', or nil if there is none.
 func (node *Node) Parent() *Node {
-	parent := C.cmark_node_parent(node.node)
-	if parent == nil {
-		return nil
-	}
-	return &Node{node: parent}
+	return nodeOrNil(C.cmark_node_parent(node.node))
 }
 
 // FirstChild wraps cmark_node_first_child
 // Returns the first child of 'node', or nil if 'node' has no children.
 func (node *Node) FirstChild() *Node {
-	firstChild := C.cmark_node_first_child(node.node)
-	if firstChild == nil {
-		return nil
-	}
-	return &Node{node: firstChild}
+	return nodeOrNil(C.cmark_node_first_child(node.node))
 }
 
 // LastChild wraps cmark_node_last_child
 // Returns the last child of 'node', or nil if 'node' has no children.
 func (node *Node) LastChild() *Node {
-	lastChild := C.cmark_node_last_child(node.node)
-	if lastChild == nil {
+	return nodeOrNil(C.cmark_node_last_child(node.node))
+}
+
+// some cmark functions like `cmark_node_get_url` reutrn a `char *` that will
+// be `NULL` if the relevant data can't be fetch (e.g. if the node doesn't
+// actually contain a URL) this preserves that behaviour
+// this could probably be somewhere shared, but https://github.com/golang/go/issues/13467
+func stringOrNil(s *C.char) *string {
+	if s == nil {
 		return nil
 	}
 
-	return &Node{node: lastChild}
+	str := C.GoString(s)
+	return &str
+}
+
+func nodeOrNil(n *C.cmark_node) *Node {
+	if n == nil {
+		return nil
+	}
+
+	return &Node{node: n}
 }

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -258,10 +258,10 @@ func TestGetFenceInfoNoInfo(t *testing.T) {
 }
 
 func TestGetFenceInfo(t *testing.T) {
-	for _, tc := range []struct{
-		content string
+	for _, tc := range []struct {
+		content  string
 		expected string
-	} {
+	}{
 		{"```bash\necho 'hello'\n```\n", "bash"},
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -248,6 +248,32 @@ func TestIsTightList(t *testing.T) {
 	}
 }
 
+func TestGetFenceInfoNoInfo(t *testing.T) {
+	document := ParseDocument("No code fence\n", ParserOptDefault)
+
+	content := document.FirstChild()
+	require.NotNil(t, content)
+
+	require.Nil(t, content.GetFenceInfo())
+}
+
+func TestGetFenceInfo(t *testing.T) {
+	for _, tc := range []struct{
+		content string
+		expected string
+	} {
+		{"```bash\necho 'hello'\n```\n", "bash"},
+		{"~~~python\nprint('hello')\n~~~\n", "python"},
+	} {
+		t.Run(tc.content, func(t *testing.T) {
+			document := ParseDocument(tc.content, ParserOptDefault)
+			fenceNode := document.FirstChild()
+
+			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
+		})
+	}
+}
+
 func TestGetUrlNoUrl(t *testing.T) {
 	document := ParseDocument("No URL here\n", ParserOptDefault)
 

--- a/pkg/cmark/parser.go
+++ b/pkg/cmark/parser.go
@@ -48,7 +48,6 @@ const (
 	ParserOptSmart ParserOpt = C.CMARK_OPT_SMART
 )
 
-
 // free wraps cmark_parser_free
 func (parser *Parser) free() { //go-cov:skip
 	C.cmark_parser_free(parser.parser)


### PR DESCRIPTION
- Add helpers to handle pointer returns

- Add wrappers for cmark_node_get_fence_info

- Fix casing for in 'Footnote' for consistency

- Fix golangci-lint skip patter

    This was the cause of the lack of errors reported when linting in
    74c89f51292b4ff6a3eb6481a90b2218ed16a51f...

- Format code

    With the above skipping removed, re-run the linter

- Add wrapper for cmark_node_parent_footnote_def