### PR TITLE
Add `pre-commit` config

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -28,7 +28,7 @@ jobs:
           BEGIN {fail = 0}
           NR > 1 && $NF == 0 { fail = 1; printf("bad line: %s\n", $0) }
           END { if (fail) { exit(1) } }'
-  lint:
+  golangci-lint:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -39,3 +39,12 @@ jobs:
           cache: false
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0
+      env:
+        # run this separately since it handles it's own caching
+        SKIP: golangci-lint

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -1,4 +1,4 @@
-name: tests
+name: PR Checks
 on:
   pull_request:
   push:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+-   repo: https://github.com/matthewhughes934/pre-commit-format-markdown
+    rev: v0.5.0
+    hooks:
+    -   id: format-markdown-docker
+-   repo: https://gitlab.com/matthewhughes/common-changelog
+    rev: v0.1.1
+    hooks:
+    -   id: validate-changelog
+-   repo: https://github.com/golangci/golangci-lint
+    rev: v1.53.3
+    hooks:
+    -   id: golangci-lint


### PR DESCRIPTION
Use some basic hooks, locally this includes `golangci-lint` but not in CI since it has its own action that handles the extra caching it uses