### PR TITLE
Move package comment so it's detected

### DIFF
--- a/pkg/cmark-gfm/cmark_gfm.go
+++ b/pkg/cmark-gfm/cmark_gfm.go
@@ -1,7 +1,7 @@
 // Package gfm provides Go bindings for the cmark-gfm library
+package gfm
 
 //go:generate ../../scripts/copy-lib ../../cmark-gfm-src
-package gfm
 
 /*
 #include "cmark-gfm.h"

--- a/pkg/cmark/cmark.go
+++ b/pkg/cmark/cmark.go
@@ -1,4 +1,4 @@
 // Package cmark provides Go bindings for the cmark library
+package cmark
 
 //go:generate ../../scripts/copy-lib ../../cmark-src
-package cmark


### PR DESCRIPTION
I.e. so that it shows when reading the docs e.g. with `go docs`