### PR TITLE
`gfm` improved parser opts

### DIFF
--- a/pkg/cmark-gfm/iterator_test.go
+++ b/pkg/cmark-gfm/iterator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIterAPI(t *testing.T) {
-	root := ParseDocument("# heading\n\nparagraph\n", ParserOptDefault)
+	root := ParseDocument("# heading\n\nparagraph\n", NewParserOpts())
 	iter := NewIter(root)
 
 	// step into document
@@ -52,7 +52,7 @@ func TestIterAPI(t *testing.T) {
 }
 
 func ExampleIter() {
-	root := ParseDocument("# Document\n\nsome text\n", ParserOptDefault)
+	root := ParseDocument("# Document\n\nsome text\n", NewParserOpts())
 	iter := NewIter(root)
 
 	evType := iter.Next()

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -11,7 +11,7 @@ import (
 func TestParseSimpleDocument(t *testing.T) {
 	document := "# My Document\n\nthis is a great document!\n"
 
-	got := ParseDocument(document, ParserOptDefault)
+	got := ParseDocument(document, NewParserOpts())
 	require.NotNil(t, got)
 
 	assert.Equal(t, NodeTypeDocument, got.GetType())
@@ -64,7 +64,7 @@ func TestGetLiteralNoContent(t *testing.T) {
 
 func TestGetLiteralWithContent(t *testing.T) {
 	content := "# heading\n"
-	document := ParseDocument(content, ParserOptDefault)
+	document := ParseDocument(content, NewParserOpts())
 	require.NotNil(t, document)
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -75,14 +75,14 @@ func TestGetLiteralWithContent(t *testing.T) {
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
-	got := ParseDocument("", ParserOptDefault)
+	got := ParseDocument("", NewParserOpts())
 	require.NotNil(t, got)
 
 	assert.Nil(t, got.FirstChild())
 }
 
 func TestNodeFirstChild(t *testing.T) {
-	got := ParseDocument("# heading\n", ParserOptDefault)
+	got := ParseDocument("# heading\n", NewParserOpts())
 	require.NotNil(t, got)
 
 	firstChild := got.FirstChild()
@@ -91,13 +91,13 @@ func TestNodeFirstChild(t *testing.T) {
 }
 
 func TestLastChildNoChild(t *testing.T) {
-	document := ParseDocument("", ParserOptDefault)
+	document := ParseDocument("", NewParserOpts())
 
 	assert.Nil(t, document.LastChild())
 }
 
 func TestLastChild(t *testing.T) {
-	document := ParseDocument("# heading\n\nparagraph\n", ParserOptDefault)
+	document := ParseDocument("# heading\n\nparagraph\n", NewParserOpts())
 
 	lastChild := document.LastChild()
 	require.NotNil(t, lastChild)
@@ -105,7 +105,7 @@ func TestLastChild(t *testing.T) {
 }
 
 func TestParentFootnoteDef(t *testing.T) {
-	document := ParseDocument("Here's a simple footnote[^1]\n\n[^1]: My Reference\n", ParserOptDefault|ParserOptFootnotes)
+	document := ParseDocument("Here's a simple footnote[^1]\n\n[^1]: My Reference\n", NewParserOpts().WithFoonotes())
 
 	// document->paragraph->text->footnote
 	footnoteRef := document.FirstChild().FirstChild().Next()
@@ -117,14 +117,14 @@ func TestParentFootnoteDef(t *testing.T) {
 }
 
 func TestNodeNextNoNext(t *testing.T) {
-	document := ParseDocument("", ParserOptDefault)
+	document := ParseDocument("", NewParserOpts())
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Next())
 }
 
 func TestNodeNext(t *testing.T) {
-	document := ParseDocument("first paragraph\n\nsecond paragraph\n", ParserOptDefault)
+	document := ParseDocument("first paragraph\n\nsecond paragraph\n", NewParserOpts())
 
 	firstParagraph := document.FirstChild()
 	require.Equal(t, NodeTypeParagraph, firstParagraph.GetType())
@@ -136,14 +136,14 @@ func TestNodeNext(t *testing.T) {
 }
 
 func TestNodePreviousNoPrevious(t *testing.T) {
-	document := ParseDocument("", ParserOptDefault)
+	document := ParseDocument("", NewParserOpts())
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Previous())
 }
 
 func TestNodePrevious(t *testing.T) {
-	document := ParseDocument("first paragraph\n\nsecond paragraph\n", ParserOptDefault)
+	document := ParseDocument("first paragraph\n\nsecond paragraph\n", NewParserOpts())
 
 	secondParagraph := document.FirstChild().Next()
 	require.Equal(t, NodeTypeParagraph, secondParagraph.GetType())
@@ -155,14 +155,14 @@ func TestNodePrevious(t *testing.T) {
 }
 
 func TestNodeParentNoParent(t *testing.T) {
-	document := ParseDocument("", ParserOptDefault)
+	document := ParseDocument("", NewParserOpts())
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Parent())
 }
 
 func TestNodeParent(t *testing.T) {
-	document := ParseDocument("# heading\n", ParserOptDefault)
+	document := ParseDocument("# heading\n", NewParserOpts())
 
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -173,7 +173,7 @@ func TestNodeParent(t *testing.T) {
 }
 
 func TestGetHeadingLevelNotHeading(t *testing.T) {
-	document := ParseDocument("", ParserOptDefault)
+	document := ParseDocument("", NewParserOpts())
 
 	require.Equal(t, 0, document.GetHeadingLevel())
 }
@@ -187,7 +187,7 @@ func TestGetHeadingLevel(t *testing.T) {
 		{"## heading", 2},
 	} {
 		t.Run(tc.heading, func(t *testing.T) {
-			document := ParseDocument(tc.heading+"\n", ParserOptDefault)
+			document := ParseDocument(tc.heading+"\n", NewParserOpts())
 
 			heading := document.FirstChild()
 			require.NotNil(t, heading)
@@ -207,7 +207,7 @@ func TestGetListType(t *testing.T) {
 		{"1. foo\n2. bar", TypeOrderedList},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", ParserOptDefault)
+			document := ParseDocument(tc.content+"\n", NewParserOpts())
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -228,7 +228,7 @@ func TestGetListStart(t *testing.T) {
 		{"2. foo\n3. bar", 2},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", ParserOptDefault)
+			document := ParseDocument(tc.content+"\n", NewParserOpts())
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -248,7 +248,7 @@ func TestIsTightList(t *testing.T) {
 		{"* tight\n*list", true},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", ParserOptDefault)
+			document := ParseDocument(tc.content+"\n", NewParserOpts())
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -259,7 +259,7 @@ func TestIsTightList(t *testing.T) {
 }
 
 func TestGetFenceInfoNoInfo(t *testing.T) {
-	document := ParseDocument("No code fence\n", ParserOptDefault)
+	document := ParseDocument("No code fence\n", NewParserOpts())
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -276,7 +276,7 @@ func TestGetFenceInfo(t *testing.T) {
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, ParserOptDefault)
+			document := ParseDocument(tc.content, NewParserOpts())
 			fenceNode := document.FirstChild()
 
 			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
@@ -285,7 +285,7 @@ func TestGetFenceInfo(t *testing.T) {
 }
 
 func TestGetUrlNoUrl(t *testing.T) {
-	document := ParseDocument("No URL here\n", ParserOptDefault)
+	document := ParseDocument("No URL here\n", NewParserOpts())
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -304,7 +304,7 @@ func TestGetURL(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some-title")`, "https://example.com/image.png"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, ParserOptDefault)
+			document := ParseDocument(tc.content, NewParserOpts())
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -320,7 +320,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 		"* list point",
 	} {
 		t.Run(content, func(t *testing.T) {
-			document := ParseDocument(content, ParserOptDefault)
+			document := ParseDocument(content, NewParserOpts())
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -340,7 +340,7 @@ func TestGetTitle(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some title")`, "some title"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, ParserOptDefault)
+			document := ParseDocument(tc.content, NewParserOpts())
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -352,7 +352,7 @@ func TestGetTitle(t *testing.T) {
 func TestNodePositionFunctions(t *testing.T) {
 	content := "# heading\nparagraph that\nlasts\nseveral\nlines\n"
 
-	document := ParseDocument(content, ParserOptDefault)
+	document := ParseDocument(content, NewParserOpts())
 
 	headingNode := document.FirstChild()
 	require.NotNil(t, headingNode)
@@ -372,7 +372,7 @@ func TestNodePositionFunctions(t *testing.T) {
 
 func ExampleParseDocument() {
 	document := "# My great document\n\nWhat a great read!\n"
-	root := ParseDocument(document, ParserOptDefault)
+	root := ParseDocument(document, NewParserOpts())
 
 	heading := root.FirstChild()
 	headingContent := heading.FirstChild()

--- a/pkg/cmark-gfm/parser_test.go
+++ b/pkg/cmark-gfm/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParserAPI(t *testing.T) {
-	parser := NewParser(ParserOptDefault)
+	parser := NewParser(NewParserOpts())
 	document := "# heading\n\nparagraph here\n"
 
 	scanner := bufio.NewScanner(strings.NewReader(document))
@@ -27,4 +27,37 @@ func TestParserAPI(t *testing.T) {
 
 	require.Equal(t, NodeTypeHeading, firstChild.GetType())
 	require.Equal(t, NodeTypeParagraph, nextNode.GetType())
+}
+
+func TestParserOpts(t *testing.T) {
+	for _, tc := range []struct {
+		content  string
+		opts     *ParserOpts
+		expected string
+	}{
+		{
+			"plain paragraph",
+			NewParserOpts(),
+			"plain paragraph",
+		},
+		{
+			"bad UTF8: \xFF",
+			NewParserOpts().WithValidateUTF8(),
+			"bad UTF8: �",
+		},
+		{
+			`text -- "with quotes" ---`,
+			NewParserOpts().WithSmart(),
+			"text – “with quotes” —",
+		},
+	} {
+		t.Run(tc.content, func(t *testing.T) {
+			document := ParseDocument(tc.content, tc.opts)
+			parsedContent := document.FirstChild().FirstChild().GetLiteral()
+			t.Log(RenderHTML(document, NewRenderOpts()))
+
+			require.NotNil(t, parsedContent)
+			require.Equal(t, tc.expected, *parsedContent)
+		})
+	}
 }

--- a/pkg/cmark-gfm/render.go
+++ b/pkg/cmark-gfm/render.go
@@ -59,6 +59,14 @@ func (o *RenderOpts) WithGithubPreLang() *RenderOpts {
 	return o
 }
 
+// WithFullInfoString maps to C.CMARK_OPT_FULL_INFO_STRING
+// Includes the remainder of the info string in code blocks in
+// a separate attribute.
+func (o *RenderOpts) WithFullInfoString() *RenderOpts {
+	o.o |= C.CMARK_OPT_FULL_INFO_STRING
+	return o
+}
+
 // RenderCommonMark wraps `cmark_render_commonmark`.
 // Returns the tree under `root` rendered as a commonmark document
 func RenderCommonMark(root *Node, opts *RenderOpts, width int) string {

--- a/pkg/cmark-gfm/render.go
+++ b/pkg/cmark-gfm/render.go
@@ -51,6 +51,14 @@ func (o *RenderOpts) WithNoBreaks() *RenderOpts {
 	return o
 }
 
+// WithGithubPreLang maps to C.CMARK_OPT_GITHUB_PRE_LANG
+// Uses GitHub-style <pre lang="x"> tags for code blocks instead of <pre><code
+// class="language-x">.
+func (o *RenderOpts) WithGithubPreLang() *RenderOpts {
+	o.o |= C.CMARK_OPT_GITHUB_PRE_LANG
+	return o
+}
+
 // RenderCommonMark wraps `cmark_render_commonmark`.
 // Returns the tree under `root` rendered as a commonmark document
 func RenderCommonMark(root *Node, opts *RenderOpts, width int) string {

--- a/pkg/cmark-gfm/render_test.go
+++ b/pkg/cmark-gfm/render_test.go
@@ -73,6 +73,11 @@ func TestRenderHTML(t *testing.T) {
 			NewRenderOpts().WithNoBreaks(),
 			"<p>plain paragraph with two lines</p>\n",
 		},
+		{
+			"```python\nprint ('hello, world!)\n```\n",
+			NewRenderOpts().WithGithubPreLang(),
+			`<pre lang="python"><code>print ('hello, world!)` + "\n</code></pre>" + "\n",
+		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
 			root := ParseDocument(tc.content, ParserOptDefault)

--- a/pkg/cmark-gfm/render_test.go
+++ b/pkg/cmark-gfm/render_test.go
@@ -31,7 +31,7 @@ func TestRenderCommonMark(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			document := ParseDocument(tc.content, ParserOptDefault)
+			document := ParseDocument(tc.content, NewParserOpts())
 			require.Equal(t, tc.expected, RenderCommonMark(document, NewRenderOpts(), tc.width))
 		})
 	}
@@ -78,9 +78,14 @@ func TestRenderHTML(t *testing.T) {
 			NewRenderOpts().WithGithubPreLang(),
 			`<pre lang="python"><code>print ('hello, world!)` + "\n</code></pre>" + "\n",
 		},
+		{
+			"```python version=3.10\nprint ('hello, world!)\n```\n",
+			NewRenderOpts().WithFullInfoString(),
+			`<pre><code class="language-python" data-meta="version=3.10">print ('hello, world!)` + "\n</code></pre>" + "\n",
+		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			root := ParseDocument(tc.content, ParserOptDefault)
+			root := ParseDocument(tc.content, NewParserOpts())
 
 			require.Equal(t, tc.expected, RenderHTML(root, tc.opts))
 		})


### PR DESCRIPTION
- Add `WithGithubPreLang` as render opts

    I was a bit confused since in `cmark-gfm.h` this is with the other
    parsing opts, but it affects rendering.

- gfm: add nicer interface for parser opts

    Again basically just copying the interface over from
    31abeac02f35afa66bf5c28e7b7d6078a003ed29. There are two more parser opts
    that I've skipped here:

    * `CMARK_OPT_STRIKETHROUGH_DOUBLE_TILDE` this won't do anything until we
      support the strikethrough extension
    * `CMARK_OPT_TABLE_PREFER_STYLE_ATTRIBUTES` this won't do anything until
      we support the table extension
