### PR TITLE
Fix footnote tests

### DIFF
--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -3,6 +3,7 @@ package gfm
 /*
 #include <stdlib.h>
 #include "cmark-gfm.h"
+#include "node.h"
 */
 import "C"
 

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -28,7 +28,7 @@ const (
 	NodeTypeParagraph          NodeType = C.CMARK_NODE_PARAGRAPH
 	NodeTypeHeading            NodeType = C.CMARK_NODE_HEADING
 	NodeTypeThematicBreak      NodeType = C.CMARK_NODE_THEMATIC_BREAK
-	NoteTypeFootnoteDefinition NodeType = C.CMARK_NODE_FOOTNOTE_DEFINITION
+	NodeTypeFootnoteDefinition NodeType = C.CMARK_NODE_FOOTNOTE_DEFINITION
 
 	NodeTypeFirstBlock NodeType = C.CMARK_NODE_DOCUMENT
 	NodeTypeLastBlock  NodeType = C.CMARK_NODE_THEMATIC_BREAK

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -107,11 +107,12 @@ func TestLastChild(t *testing.T) {
 func TestParentFootnoteDef(t *testing.T) {
 	document := ParseDocument("Here's a simple footnote[^1]\n\n[^1]: My Reference\n", NewParserOpts().WithFoonotes())
 
-	// document->paragraph->text->footnote
+	// document->paragraph->text->footnote reference
 	footnoteRef := document.FirstChild().FirstChild().Next()
-	// document->(2nd)paragraph->footnote
-	footnoteDef := document.FirstChild().Next().FirstChild()
+	footnoteDef := document.FirstChild().Next()
 
+	require.Equal(t, footnoteRef.GetType(), NodeTypeFootnoteReference)
+	require.Equal(t, footnoteDef.GetType(), NodeTypeFootnoteDefinition)
 	require.Nil(t, footnoteDef.ParentFootnoteDef())
 	require.Equal(t, footnoteRef.ParentFootnoteDef(), footnoteDef)
 }


### PR DESCRIPTION
- Fix typo in name of footenote def type

- Fix footnote test

    I wasn't finding the right node in this test, which wasn't failing
    because Go had no idea about the members of the `cmark_node` struct and
    hence couldn't do a proper comparison. So fix the node finding logic and
    include `node.h` so we can do proper comparisons.