### PR TITLE
Misc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![coverage](https://img.shields.io/badge/Coverage-100%25-brightgreen)](https://github.com/matthewhughes934/go-cmark)
 [![Go
 Reference](https://pkg.go.dev/badge/github.com/matthewhughes934/go-cmark.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark)
+[![Pipeline
+Statues](https://github.com/matthewhughes934/go-cmark/actions/workflows/pr.yaml/badge.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark?branch=main)
 
 Go bindings for [`cmark`](https://github.com/commonmark/cmark) and
 [`cmark-gfm`](https://github.com/github/cmark-gfm)

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -2,7 +2,16 @@ package gfm
 
 import (
 	"fmt"
+	"os"
+	"testing"
 )
+
+func TestMain(m *testing.M) {
+	CoreExtensionsEnsureRegistered()
+	defer ReleasePlugins()
+
+	os.Exit(m.Run())
+}
 
 func Example() {
 	document := "# My great document\n\nWhat a great read!\n"

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -40,3 +40,18 @@ func Example() {
 	// true
 	// What a great read!
 }
+
+func Example_extensions() {
+	CoreExtensionsEnsureRegistered()
+	document := "# My document\nWith ~~no~~ an extension\n"
+	parser := NewParser(NewParserOpts())
+	parser.AttachSyntaxExtension(FindSyntaxExtension("strikethrough"))
+
+	root := parser.ParseDocument(document)
+
+	fmt.Print(RenderHTML(root, NewRenderOpts(), parser.SyntaxExtensions()))
+
+	// Output:
+	// <h1>My document</h1>
+	// <p>With <del>no</del> an extension</p>
+}

--- a/pkg/cmark-gfm/extension.go
+++ b/pkg/cmark-gfm/extension.go
@@ -28,7 +28,7 @@ func CoreExtensionsEnsureRegistered() {
 
 // ReleasePlugins wraps cmark_release_plugins.
 // Frees the memory allocated when registering psyntax extensions.
-func ReleasePlugins() {
+func ReleasePlugins() { //go-cov:skip this is only run at the end of tests
 	C.cmark_release_plugins()
 }
 

--- a/pkg/cmark-gfm/extension_test.go
+++ b/pkg/cmark-gfm/extension_test.go
@@ -7,9 +7,6 @@ import (
 )
 
 func TestExtensions(t *testing.T) {
-	CoreExtensionsEnsureRegistered()
-	defer ReleasePlugins()
-
 	for _, tc := range []struct {
 		content       string
 		renderOpts    *RenderOpts

--- a/pkg/cmark/.gitattributes
+++ b/pkg/cmark/.gitattributes
@@ -1,5 +1,5 @@
 # tell GitHub to ignore these files when determining
 # repo language
-*.c     linguist-vendored
-*.h     linguist-vendored
-*.inc   linguist-vendored
+*.c     linguist-vendored linguist-generated -diff
+*.h     linguist-vendored linguist-generated -diff
+*.inc   linguist-vendored linguist-generated -diff

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -1,0 +1,33 @@
+package cmark
+
+import (
+	"fmt"
+)
+
+func Example() {
+	document := "# My great document\n\nWhat a great read!\n"
+	root := ParseDocument(document, NewParserOpts())
+
+	heading := root.FirstChild()
+	headingContent := heading.FirstChild()
+
+	paragraph := heading.Next()
+	paragraphContent := paragraph.FirstChild()
+
+	fmt.Println(root.GetTypeString())
+	fmt.Println(heading.GetTypeString())
+	fmt.Println(headingContent.GetType() == NodeTypeText)
+	fmt.Println(*headingContent.GetLiteral())
+	fmt.Println(paragraph.GetTypeString())
+	fmt.Println(paragraphContent.GetType() == NodeTypeText)
+	fmt.Println(*paragraphContent.GetLiteral())
+
+	// Output:
+	// document
+	// heading
+	// true
+	// My great document
+	// paragraph
+	// true
+	// What a great read!
+}

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -1,7 +1,6 @@
 package cmark
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -358,32 +357,4 @@ func TestNodePositionFunctions(t *testing.T) {
 	assert.Equal(t, 5, paragraphNode.GetEndLine())
 	assert.Equal(t, 1, paragraphNode.GetStartColumn())
 	assert.Equal(t, 5, paragraphNode.GetEndColumn())
-}
-
-func ExampleParseDocument() {
-	document := "# My great document\n\nWhat a great read!\n"
-	root := ParseDocument(document, NewParserOpts())
-
-	heading := root.FirstChild()
-	headingContent := heading.FirstChild()
-
-	paragraph := heading.Next()
-	paragraphContent := paragraph.FirstChild()
-
-	fmt.Println(root.GetTypeString())
-	fmt.Println(heading.GetTypeString())
-	fmt.Println(headingContent.GetType() == NodeTypeText)
-	fmt.Println(*headingContent.GetLiteral())
-	fmt.Println(paragraph.GetTypeString())
-	fmt.Println(paragraphContent.GetType() == NodeTypeText)
-	fmt.Println(*paragraphContent.GetLiteral())
-
-	// Output:
-	// document
-	// heading
-	// true
-	// My great document
-	// paragraph
-	// true
-	// What a great read!
 }


### PR DESCRIPTION
- Update cmark attributes

    Copy the changes across for 336cf5e59cd092c1dbd14b8e93680efd33e0bd2c

- cmark: move examples to their own file

    Again, just copying changes over from gfm:
    c210bed5b3f93f079cecd6207e5e6edac55b66e0

- Add badge for pipeline status

    Because why not

- Move extension handling in tests

    Make the setup and teardown for this be across an entire test run, to
    avoid one test cleaning the extensions so that others can't use them

- Add example for using extensions