### PR TITLE
Cmark parse document as method

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go
 Reference](https://pkg.go.dev/badge/github.com/matthewhughes934/go-cmark.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark)
 [![Pipeline
-Statues](https://github.com/matthewhughes934/go-cmark/actions/workflows/pr.yaml/badge.svg)](https://pkg.go.dev/github.com/matthewhughes934/go-cmark?branch=main)
+Statues](https://github.com/matthewhughes934/go-cmark/actions/workflows/pr.yaml/badge.svg?branch=main)](https://github.com/matthewhughes934/go-cmark)
 
 Go bindings for [`cmark`](https://github.com/commonmark/cmark) and
 [`cmark-gfm`](https://github.com/github/cmark-gfm)

--- a/cmd/cmark-ast/main.go
+++ b/cmd/cmark-ast/main.go
@@ -36,7 +36,7 @@ func cmarkAST(args []string) error {
 		return fmt.Errorf("Error reading file %s: %v", args[1], err)
 	}
 
-	dumpTree(cmark.ParseDocument(string(content), cmark.NewParserOpts()), 0)
+	dumpTree(cmark.NewParser(cmark.NewParserOpts()).ParseDocument(string(content)), 0)
 	return nil
 }
 

--- a/cmd/cmark-go/main.go
+++ b/cmd/cmark-go/main.go
@@ -52,7 +52,7 @@ func renderFiles(filenames []string, width int) error {
 		if err != nil {
 			return fmt.Errorf("Failed to read %s: %v", filename, err)
 		}
-		document := cmark.ParseDocument(string(content), cmark.NewParserOpts())
+		document := cmark.NewParser(cmark.NewParserOpts()).ParseDocument(string(content))
 		fmt.Print(cmark.RenderCommonMark(document, cmark.NewRenderOpts(), width))
 	}
 	return nil

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -6,7 +6,7 @@ import (
 
 func Example() {
 	document := "# My great document\n\nWhat a great read!\n"
-	root := ParseDocument(document, NewParserOpts())
+	root := NewParser(NewParserOpts()).ParseDocument(document)
 
 	heading := root.FirstChild()
 	headingContent := heading.FirstChild()

--- a/pkg/cmark/iterator_test.go
+++ b/pkg/cmark/iterator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIterAPI(t *testing.T) {
-	root := ParseDocument("# heading\n\nparagraph\n", NewParserOpts())
+	root := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
 	iter := NewIter(root)
 
 	// step into document
@@ -52,7 +52,7 @@ func TestIterAPI(t *testing.T) {
 }
 
 func ExampleIter() {
-	root := ParseDocument("# Document\n\nsome text\n", NewParserOpts())
+	root := NewParser(NewParserOpts()).ParseDocument("# Document\n\nsome text\n")
 	iter := NewIter(root)
 
 	evType := iter.Next()

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseSimpleDocument(t *testing.T) {
 	document := "# My Document\n\nthis is a great document!\n"
 
-	got := ParseDocument(document, NewParserOpts())
+	got := NewParser(NewParserOpts()).ParseDocument(document)
 	require.NotNil(t, got)
 
 	assert.Equal(t, NodeTypeDocument, got.GetType())
@@ -65,7 +65,7 @@ func TestGetLiteralNoContent(t *testing.T) {
 
 func TestGetLiteralWithContent(t *testing.T) {
 	content := "# heading\n"
-	document := ParseDocument(content, NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument(content)
 	require.NotNil(t, document)
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -76,14 +76,14 @@ func TestGetLiteralWithContent(t *testing.T) {
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
-	got := ParseDocument("", NewParserOpts())
+	got := NewParser(NewParserOpts()).ParseDocument("")
 	require.NotNil(t, got)
 
 	assert.Nil(t, got.FirstChild())
 }
 
 func TestNodeFirstChild(t *testing.T) {
-	got := ParseDocument("# heading\n", NewParserOpts())
+	got := NewParser(NewParserOpts()).ParseDocument("# heading\n")
 	require.NotNil(t, got)
 
 	firstChild := got.FirstChild()
@@ -92,13 +92,13 @@ func TestNodeFirstChild(t *testing.T) {
 }
 
 func TestLastChildNoChild(t *testing.T) {
-	document := ParseDocument("", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("")
 
 	assert.Nil(t, document.LastChild())
 }
 
 func TestLastChild(t *testing.T) {
-	document := ParseDocument("# heading\n\nparagraph\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
 
 	lastChild := document.LastChild()
 	require.NotNil(t, lastChild)
@@ -106,14 +106,14 @@ func TestLastChild(t *testing.T) {
 }
 
 func TestNodeNextNoNext(t *testing.T) {
-	document := ParseDocument("", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Next())
 }
 
 func TestNodeNext(t *testing.T) {
-	document := ParseDocument("first paragraph\n\nsecond paragraph\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	firstParagraph := document.FirstChild()
 	require.Equal(t, NodeTypeParagraph, firstParagraph.GetType())
@@ -125,14 +125,14 @@ func TestNodeNext(t *testing.T) {
 }
 
 func TestNodePreviousNoPrevious(t *testing.T) {
-	document := ParseDocument("", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Previous())
 }
 
 func TestNodePrevious(t *testing.T) {
-	document := ParseDocument("first paragraph\n\nsecond paragraph\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	secondParagraph := document.FirstChild().Next()
 	require.Equal(t, NodeTypeParagraph, secondParagraph.GetType())
@@ -144,14 +144,14 @@ func TestNodePrevious(t *testing.T) {
 }
 
 func TestNodeParentNoParent(t *testing.T) {
-	document := ParseDocument("", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Parent())
 }
 
 func TestNodeParent(t *testing.T) {
-	document := ParseDocument("# heading\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("# heading\n")
 
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -162,7 +162,7 @@ func TestNodeParent(t *testing.T) {
 }
 
 func TestGetHeadingLevelNotHeading(t *testing.T) {
-	document := ParseDocument("", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("")
 
 	require.Equal(t, 0, document.GetHeadingLevel())
 }
@@ -176,7 +176,7 @@ func TestGetHeadingLevel(t *testing.T) {
 		{"## heading", 2},
 	} {
 		t.Run(tc.heading, func(t *testing.T) {
-			document := ParseDocument(tc.heading+"\n", NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.heading + "\n")
 
 			heading := document.FirstChild()
 			require.NotNil(t, heading)
@@ -196,7 +196,7 @@ func TestGetListType(t *testing.T) {
 		{"1. foo\n2. bar", TypeOrderedList},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -217,7 +217,7 @@ func TestGetListStart(t *testing.T) {
 		{"2. foo\n3. bar", 2},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -237,7 +237,7 @@ func TestIsTightList(t *testing.T) {
 		{"* tight\n*list", true},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content+"\n", NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -248,7 +248,7 @@ func TestIsTightList(t *testing.T) {
 }
 
 func TestGetFenceInfoNoInfo(t *testing.T) {
-	document := ParseDocument("No code fence\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("No code fence\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -265,7 +265,7 @@ func TestGetFenceInfo(t *testing.T) {
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
 			fenceNode := document.FirstChild()
 
 			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
@@ -274,7 +274,7 @@ func TestGetFenceInfo(t *testing.T) {
 }
 
 func TestGetUrlNoUrl(t *testing.T) {
-	document := ParseDocument("No URL here\n", NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument("No URL here\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -293,7 +293,7 @@ func TestGetURL(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some-title")`, "https://example.com/image.png"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -309,7 +309,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 		"* list point",
 	} {
 		t.Run(content, func(t *testing.T) {
-			document := ParseDocument(content, NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -329,7 +329,7 @@ func TestGetTitle(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some title")`, "some title"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -341,7 +341,7 @@ func TestGetTitle(t *testing.T) {
 func TestNodePositionFunctions(t *testing.T) {
 	content := "# heading\nparagraph that\nlasts\nseveral\nlines\n"
 
-	document := ParseDocument(content, NewParserOpts())
+	document := NewParser(NewParserOpts()).ParseDocument(content)
 
 	headingNode := document.FirstChild()
 	require.NotNil(t, headingNode)

--- a/pkg/cmark/parser.go
+++ b/pkg/cmark/parser.go
@@ -70,18 +70,13 @@ func (parser *Parser) Finish() *Node {
 	}
 }
 
-// ParseDocument wraps cmark_parse_document.
-// Parses a CommonMark document in 'document' and returns a pointer to a tree of nodes.
+// ParseDocument parses a CommonMark document in 'document' and returns a pointer to a tree of nodes.
 // The returned [cmark.Node] has a finalizer set that will call
 // `cmark_node_free` which will free the memory allocated for the node and any
 // of its children
-func ParseDocument(document string, opts *ParserOpts) *Node {
-	str := C.CString(document)
-	defer C.free(unsafe.Pointer(str))
-
-	node := &Node{
-		node: C.cmark_parse_document(str, C.size_t(len(document)), opts.o),
-	}
+func (parser *Parser) ParseDocument(document string) *Node {
+	parser.Feed(document)
+	node := parser.Finish()
 	runtime.SetFinalizer(node, (*Node).free)
 
 	return node

--- a/pkg/cmark/parser_test.go
+++ b/pkg/cmark/parser_test.go
@@ -52,7 +52,7 @@ func TestParserOpts(t *testing.T) {
 		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := ParseDocument(tc.content, tc.opts)
+			document := NewParser(tc.opts).ParseDocument(tc.content)
 			parsedContent := document.FirstChild().FirstChild().GetLiteral()
 
 			require.NotNil(t, parsedContent)

--- a/pkg/cmark/render_test.go
+++ b/pkg/cmark/render_test.go
@@ -31,7 +31,7 @@ func TestRenderCommonMark(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			document := ParseDocument(tc.content, NewParserOpts())
+			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
 			require.Equal(t, tc.expected, RenderCommonMark(document, NewRenderOpts(), tc.width))
 		})
 	}
@@ -75,7 +75,7 @@ func TestRenderHTML(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			root := ParseDocument(tc.content, NewParserOpts())
+			root := NewParser(NewParserOpts()).ParseDocument(tc.content)
 
 			require.Equal(t, tc.expected, RenderHTML(root, tc.opts))
 		})


### PR DESCRIPTION
- Fix badge link

- cmark: add ParseDocument methond on parser

    I.e. copying across d7cf3ec8defe0ff786a03ccb462417e90eda3e4b