### PR TITLE
Remove `ParserOpts`

### DIFF
--- a/cmd/cmark-ast/main.go
+++ b/cmd/cmark-ast/main.go
@@ -36,7 +36,7 @@ func cmarkAST(args []string) error {
 		return fmt.Errorf("Error reading file %s: %v", args[1], err)
 	}
 
-	dumpTree(cmark.NewParser(cmark.NewParserOpts()).ParseDocument(string(content)), 0)
+	dumpTree(cmark.NewParser().ParseDocument(string(content)), 0)
 	return nil
 }
 

--- a/cmd/cmark-go/main.go
+++ b/cmd/cmark-go/main.go
@@ -52,7 +52,7 @@ func renderFiles(filenames []string, width int) error {
 		if err != nil {
 			return fmt.Errorf("Failed to read %s: %v", filename, err)
 		}
-		document := cmark.NewParser(cmark.NewParserOpts()).ParseDocument(string(content))
+		document := cmark.NewParser().ParseDocument(string(content))
 		fmt.Print(cmark.RenderCommonMark(document, cmark.NewRenderOpts(), width))
 	}
 	return nil

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -15,7 +15,7 @@ func TestMain(m *testing.M) {
 
 func Example() {
 	document := "# My great document\n\nWhat a great read!\n"
-	root := NewParser(NewParserOpts()).ParseDocument(document)
+	root := NewParser().ParseDocument(document)
 
 	heading := root.FirstChild()
 	headingContent := heading.FirstChild()
@@ -44,7 +44,7 @@ func Example() {
 func Example_extensions() {
 	CoreExtensionsEnsureRegistered()
 	document := "# My document\nWith ~~no~~ an extension\n"
-	parser := NewParser(NewParserOpts())
+	parser := NewParser()
 	parser.AttachSyntaxExtension(FindSyntaxExtension("strikethrough"))
 
 	root := parser.ParseDocument(document)

--- a/pkg/cmark-gfm/extension_test.go
+++ b/pkg/cmark-gfm/extension_test.go
@@ -47,7 +47,7 @@ func TestExtensions(t *testing.T) {
 		},
 	} {
 		t.Run(tc.extensionName, func(t *testing.T) {
-			parser := NewParser(NewParserOpts())
+			parser := NewParser()
 			extension := FindSyntaxExtension(tc.extensionName)
 			require.NotNilf(t, extension, "Failed to find extension: %s", tc.extensionName)
 			parser.AttachSyntaxExtension(extension)

--- a/pkg/cmark-gfm/iterator_test.go
+++ b/pkg/cmark-gfm/iterator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIterAPI(t *testing.T) {
-	root := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
+	root := NewParser().ParseDocument("# heading\n\nparagraph\n")
 	iter := NewIter(root)
 
 	// step into document
@@ -52,7 +52,7 @@ func TestIterAPI(t *testing.T) {
 }
 
 func ExampleIter() {
-	root := NewParser(NewParserOpts()).ParseDocument("# Document\n\nsome text\n")
+	root := NewParser().ParseDocument("# Document\n\nsome text\n")
 	iter := NewIter(root)
 
 	evType := iter.Next()

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseSimpleDocument(t *testing.T) {
 	document := "# My Document\n\nthis is a great document!\n"
 
-	got := NewParser(NewParserOpts()).ParseDocument(document)
+	got := NewParser().ParseDocument(document)
 	require.NotNil(t, got)
 
 	assert.Equal(t, NodeTypeDocument, got.GetType())
@@ -63,7 +63,7 @@ func TestGetLiteralNoContent(t *testing.T) {
 
 func TestGetLiteralWithContent(t *testing.T) {
 	content := "# heading\n"
-	document := NewParser(NewParserOpts()).ParseDocument(content)
+	document := NewParser().ParseDocument(content)
 	require.NotNil(t, document)
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -74,14 +74,14 @@ func TestGetLiteralWithContent(t *testing.T) {
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
-	got := NewParser(NewParserOpts()).ParseDocument("")
+	got := NewParser().ParseDocument("")
 	require.NotNil(t, got)
 
 	assert.Nil(t, got.FirstChild())
 }
 
 func TestNodeFirstChild(t *testing.T) {
-	got := NewParser(NewParserOpts()).ParseDocument("# heading\n")
+	got := NewParser().ParseDocument("# heading\n")
 	require.NotNil(t, got)
 
 	firstChild := got.FirstChild()
@@ -90,13 +90,13 @@ func TestNodeFirstChild(t *testing.T) {
 }
 
 func TestLastChildNoChild(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 
 	assert.Nil(t, document.LastChild())
 }
 
 func TestLastChild(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
+	document := NewParser().ParseDocument("# heading\n\nparagraph\n")
 
 	lastChild := document.LastChild()
 	require.NotNil(t, lastChild)
@@ -104,7 +104,7 @@ func TestLastChild(t *testing.T) {
 }
 
 func TestParentFootnoteDef(t *testing.T) {
-	document := NewParser(NewParserOpts().WithFoonotes()).
+	document := NewParser().WithFoonotes().
 		ParseDocument("Here's a simple footnote[^1]\n\n[^1]: My Reference\n")
 
 	// document->paragraph->text->footnote reference
@@ -118,14 +118,14 @@ func TestParentFootnoteDef(t *testing.T) {
 }
 
 func TestNodeNextNoNext(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Next())
 }
 
 func TestNodeNext(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
+	document := NewParser().ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	firstParagraph := document.FirstChild()
 	require.Equal(t, NodeTypeParagraph, firstParagraph.GetType())
@@ -137,14 +137,14 @@ func TestNodeNext(t *testing.T) {
 }
 
 func TestNodePreviousNoPrevious(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Previous())
 }
 
 func TestNodePrevious(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
+	document := NewParser().ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	secondParagraph := document.FirstChild().Next()
 	require.Equal(t, NodeTypeParagraph, secondParagraph.GetType())
@@ -156,14 +156,14 @@ func TestNodePrevious(t *testing.T) {
 }
 
 func TestNodeParentNoParent(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Parent())
 }
 
 func TestNodeParent(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("# heading\n")
+	document := NewParser().ParseDocument("# heading\n")
 
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -174,7 +174,7 @@ func TestNodeParent(t *testing.T) {
 }
 
 func TestGetHeadingLevelNotHeading(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 
 	require.Equal(t, 0, document.GetHeadingLevel())
 }
@@ -188,7 +188,7 @@ func TestGetHeadingLevel(t *testing.T) {
 		{"## heading", 2},
 	} {
 		t.Run(tc.heading, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.heading + "\n")
+			document := NewParser().ParseDocument(tc.heading + "\n")
 
 			heading := document.FirstChild()
 			require.NotNil(t, heading)
@@ -208,7 +208,7 @@ func TestGetListType(t *testing.T) {
 		{"1. foo\n2. bar", TypeOrderedList},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -229,7 +229,7 @@ func TestGetListStart(t *testing.T) {
 		{"2. foo\n3. bar", 2},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -249,7 +249,7 @@ func TestIsTightList(t *testing.T) {
 		{"* tight\n*list", true},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -260,7 +260,7 @@ func TestIsTightList(t *testing.T) {
 }
 
 func TestGetFenceInfoNoInfo(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("No code fence\n")
+	document := NewParser().ParseDocument("No code fence\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -277,7 +277,7 @@ func TestGetFenceInfo(t *testing.T) {
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 			fenceNode := document.FirstChild()
 
 			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
@@ -286,7 +286,7 @@ func TestGetFenceInfo(t *testing.T) {
 }
 
 func TestGetUrlNoUrl(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("No URL here\n")
+	document := NewParser().ParseDocument("No URL here\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -305,7 +305,7 @@ func TestGetURL(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some-title")`, "https://example.com/image.png"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -321,7 +321,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 		"* list point",
 	} {
 		t.Run(content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(content)
+			document := NewParser().ParseDocument(content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -341,7 +341,7 @@ func TestGetTitle(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some title")`, "some title"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -353,7 +353,7 @@ func TestGetTitle(t *testing.T) {
 func TestNodePositionFunctions(t *testing.T) {
 	content := "# heading\nparagraph that\nlasts\nseveral\nlines\n"
 
-	document := NewParser(NewParserOpts()).ParseDocument(content)
+	document := NewParser().ParseDocument(content)
 
 	headingNode := document.FirstChild()
 	require.NotNil(t, headingNode)

--- a/pkg/cmark-gfm/parser.go
+++ b/pkg/cmark-gfm/parser.go
@@ -13,39 +13,30 @@ import (
 	"unsafe"
 )
 
-// ParserOpts provides options for configuring parsing behaviour
-type ParserOpts struct {
-	o C.int
-}
-
-func NewParserOpts() *ParserOpts {
-	return &ParserOpts{o: C.CMARK_OPT_DEFAULT}
+type Parser struct {
+	parser *C.cmark_parser
 }
 
 // WithValidateUTF8 maps to C.CMARK_OPT_VALIDATE_UTF8.
 // Validates UTF-8 in the input before parsing, replacing illegal
 // sequences with the replacement character U+FFFD.
-func (o *ParserOpts) WithValidateUTF8() *ParserOpts {
-	o.o |= C.CMARK_OPT_VALIDATE_UTF8
-	return o
+func (p *Parser) WithValidateUTF8() *Parser {
+	p.parser.options |= C.CMARK_OPT_VALIDATE_UTF8
+	return p
 }
 
 // WithSmart maps to C.CMARK_OPT_SMART.
 // Converts straight quotes to curly, --- to em dashes, -- to en dashes.
-func (o *ParserOpts) WithSmart() *ParserOpts {
-	o.o |= C.CMARK_OPT_SMART
-	return o
+func (p *Parser) WithSmart() *Parser {
+	p.parser.options |= C.CMARK_OPT_SMART
+	return p
 }
 
 // WithFoonotes maps to c.CMARK_OPT_FOOTNOTES
 // Parses footnotes
-func (o *ParserOpts) WithFoonotes() *ParserOpts {
-	o.o |= C.CMARK_OPT_FOOTNOTES
-	return o
-}
-
-type Parser struct {
-	parser *C.cmark_parser
+func (p *Parser) WithFoonotes() *Parser {
+	p.parser.options |= C.CMARK_OPT_FOOTNOTES
+	return p
 }
 
 // free wraps cmark_parser_free
@@ -55,8 +46,8 @@ func (parser *Parser) free() { //go-cov:skip
 
 // NewParser wraps cmark_parser_new.
 // Creates a new parser object.
-func NewParser(opts *ParserOpts) *Parser {
-	parser := &Parser{parser: C.cmark_parser_new(opts.o)}
+func NewParser() *Parser {
+	parser := &Parser{parser: C.cmark_parser_new(C.CMARK_OPT_DEFAULT)}
 	runtime.SetFinalizer(parser, (*Parser).free)
 
 	return parser

--- a/pkg/cmark-gfm/parser_test.go
+++ b/pkg/cmark-gfm/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParserAPI(t *testing.T) {
-	parser := NewParser(NewParserOpts())
+	parser := NewParser()
 	document := "# heading\n\nparagraph here\n"
 
 	scanner := bufio.NewScanner(strings.NewReader(document))
@@ -32,28 +32,27 @@ func TestParserAPI(t *testing.T) {
 func TestParserOpts(t *testing.T) {
 	for _, tc := range []struct {
 		content  string
-		opts     *ParserOpts
+		parser   *Parser
 		expected string
 	}{
 		{
 			"plain paragraph",
-			NewParserOpts(),
+			NewParser(),
 			"plain paragraph",
 		},
 		{
 			"bad UTF8: \xFF",
-			NewParserOpts().WithValidateUTF8(),
+			NewParser().WithValidateUTF8(),
 			"bad UTF8: �",
 		},
 		{
 			`text -- "with quotes" ---`,
-			NewParserOpts().WithSmart(),
+			NewParser().WithSmart(),
 			"text – “with quotes” —",
 		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			parser := NewParser(tc.opts)
-			document := parser.ParseDocument(tc.content)
+			document := tc.parser.ParseDocument(tc.content)
 			parsedContent := document.FirstChild().FirstChild().GetLiteral()
 			t.Log(RenderHTML(document, NewRenderOpts(), nil))
 

--- a/pkg/cmark-gfm/render_test.go
+++ b/pkg/cmark-gfm/render_test.go
@@ -31,7 +31,7 @@ func TestRenderCommonMark(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 			require.Equal(t, tc.expected, RenderCommonMark(document, NewRenderOpts(), tc.width))
 		})
 	}
@@ -85,7 +85,7 @@ func TestRenderHTML(t *testing.T) {
 		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			root := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			root := NewParser().ParseDocument(tc.content)
 
 			require.Equal(t, tc.expected, RenderHTML(root, tc.opts, nil))
 		})

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -6,7 +6,7 @@ import (
 
 func Example() {
 	document := "# My great document\n\nWhat a great read!\n"
-	root := NewParser(NewParserOpts()).ParseDocument(document)
+	root := NewParser().ParseDocument(document)
 
 	heading := root.FirstChild()
 	headingContent := heading.FirstChild()

--- a/pkg/cmark/iterator_test.go
+++ b/pkg/cmark/iterator_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestIterAPI(t *testing.T) {
-	root := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
+	root := NewParser().ParseDocument("# heading\n\nparagraph\n")
 	iter := NewIter(root)
 
 	// step into document
@@ -52,7 +52,7 @@ func TestIterAPI(t *testing.T) {
 }
 
 func ExampleIter() {
-	root := NewParser(NewParserOpts()).ParseDocument("# Document\n\nsome text\n")
+	root := NewParser().ParseDocument("# Document\n\nsome text\n")
 	iter := NewIter(root)
 
 	evType := iter.Next()

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -10,7 +10,7 @@ import (
 func TestParseSimpleDocument(t *testing.T) {
 	document := "# My Document\n\nthis is a great document!\n"
 
-	got := NewParser(NewParserOpts()).ParseDocument(document)
+	got := NewParser().ParseDocument(document)
 	require.NotNil(t, got)
 
 	assert.Equal(t, NodeTypeDocument, got.GetType())
@@ -65,7 +65,7 @@ func TestGetLiteralNoContent(t *testing.T) {
 
 func TestGetLiteralWithContent(t *testing.T) {
 	content := "# heading\n"
-	document := NewParser(NewParserOpts()).ParseDocument(content)
+	document := NewParser().ParseDocument(content)
 	require.NotNil(t, document)
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -76,14 +76,14 @@ func TestGetLiteralWithContent(t *testing.T) {
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
-	got := NewParser(NewParserOpts()).ParseDocument("")
+	got := NewParser().ParseDocument("")
 	require.NotNil(t, got)
 
 	assert.Nil(t, got.FirstChild())
 }
 
 func TestNodeFirstChild(t *testing.T) {
-	got := NewParser(NewParserOpts()).ParseDocument("# heading\n")
+	got := NewParser().ParseDocument("# heading\n")
 	require.NotNil(t, got)
 
 	firstChild := got.FirstChild()
@@ -92,13 +92,13 @@ func TestNodeFirstChild(t *testing.T) {
 }
 
 func TestLastChildNoChild(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 
 	assert.Nil(t, document.LastChild())
 }
 
 func TestLastChild(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("# heading\n\nparagraph\n")
+	document := NewParser().ParseDocument("# heading\n\nparagraph\n")
 
 	lastChild := document.LastChild()
 	require.NotNil(t, lastChild)
@@ -106,14 +106,14 @@ func TestLastChild(t *testing.T) {
 }
 
 func TestNodeNextNoNext(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Next())
 }
 
 func TestNodeNext(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
+	document := NewParser().ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	firstParagraph := document.FirstChild()
 	require.Equal(t, NodeTypeParagraph, firstParagraph.GetType())
@@ -125,14 +125,14 @@ func TestNodeNext(t *testing.T) {
 }
 
 func TestNodePreviousNoPrevious(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Previous())
 }
 
 func TestNodePrevious(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("first paragraph\n\nsecond paragraph\n")
+	document := NewParser().ParseDocument("first paragraph\n\nsecond paragraph\n")
 
 	secondParagraph := document.FirstChild().Next()
 	require.Equal(t, NodeTypeParagraph, secondParagraph.GetType())
@@ -144,14 +144,14 @@ func TestNodePrevious(t *testing.T) {
 }
 
 func TestNodeParentNoParent(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 	require.NotNil(t, document)
 
 	assert.Nil(t, document.Parent())
 }
 
 func TestNodeParent(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("# heading\n")
+	document := NewParser().ParseDocument("# heading\n")
 
 	heading := document.FirstChild()
 	require.NotNil(t, heading)
@@ -162,7 +162,7 @@ func TestNodeParent(t *testing.T) {
 }
 
 func TestGetHeadingLevelNotHeading(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("")
+	document := NewParser().ParseDocument("")
 
 	require.Equal(t, 0, document.GetHeadingLevel())
 }
@@ -176,7 +176,7 @@ func TestGetHeadingLevel(t *testing.T) {
 		{"## heading", 2},
 	} {
 		t.Run(tc.heading, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.heading + "\n")
+			document := NewParser().ParseDocument(tc.heading + "\n")
 
 			heading := document.FirstChild()
 			require.NotNil(t, heading)
@@ -196,7 +196,7 @@ func TestGetListType(t *testing.T) {
 		{"1. foo\n2. bar", TypeOrderedList},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -217,7 +217,7 @@ func TestGetListStart(t *testing.T) {
 		{"2. foo\n3. bar", 2},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -237,7 +237,7 @@ func TestIsTightList(t *testing.T) {
 		{"* tight\n*list", true},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content + "\n")
+			document := NewParser().ParseDocument(tc.content + "\n")
 
 			list := document.FirstChild()
 			require.NotNil(t, list)
@@ -248,7 +248,7 @@ func TestIsTightList(t *testing.T) {
 }
 
 func TestGetFenceInfoNoInfo(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("No code fence\n")
+	document := NewParser().ParseDocument("No code fence\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -265,7 +265,7 @@ func TestGetFenceInfo(t *testing.T) {
 		{"~~~python\nprint('hello')\n~~~\n", "python"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 			fenceNode := document.FirstChild()
 
 			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
@@ -274,7 +274,7 @@ func TestGetFenceInfo(t *testing.T) {
 }
 
 func TestGetUrlNoUrl(t *testing.T) {
-	document := NewParser(NewParserOpts()).ParseDocument("No URL here\n")
+	document := NewParser().ParseDocument("No URL here\n")
 
 	content := document.FirstChild()
 	require.NotNil(t, content)
@@ -293,7 +293,7 @@ func TestGetURL(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some-title")`, "https://example.com/image.png"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -309,7 +309,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 		"* list point",
 	} {
 		t.Run(content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(content)
+			document := NewParser().ParseDocument(content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -329,7 +329,7 @@ func TestGetTitle(t *testing.T) {
 		{`![alt-name](https://example.com/image.png "some title")`, "some title"},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 
 			linkNode := document.FirstChild().FirstChild()
 
@@ -341,7 +341,7 @@ func TestGetTitle(t *testing.T) {
 func TestNodePositionFunctions(t *testing.T) {
 	content := "# heading\nparagraph that\nlasts\nseveral\nlines\n"
 
-	document := NewParser(NewParserOpts()).ParseDocument(content)
+	document := NewParser().ParseDocument(content)
 
 	headingNode := document.FirstChild()
 	require.NotNil(t, headingNode)

--- a/pkg/cmark/parser.go
+++ b/pkg/cmark/parser.go
@@ -3,6 +3,7 @@ package cmark
 /*
 #include "cmark.h"
 #include <stdlib.h>
+#include "parser.h"
 */
 import "C"
 
@@ -15,28 +16,19 @@ type Parser struct {
 	parser *C.cmark_parser
 }
 
-// ParserOpts provides options for configuring parsing behaviour
-type ParserOpts struct {
-	o C.int
-}
-
-func NewParserOpts() *ParserOpts {
-	return &ParserOpts{o: C.CMARK_OPT_DEFAULT}
-}
-
 // WithValidateUTF8 maps to C.CMARK_OPT_VALIDATE_UTF8.
 // Validates UTF-8 in the input before parsing, replacing illegal
 // sequences with the replacement character U+FFFD.
-func (o *ParserOpts) WithValidateUTF8() *ParserOpts {
-	o.o |= C.CMARK_OPT_VALIDATE_UTF8
-	return o
+func (p *Parser) WithValidateUTF8() *Parser {
+	p.parser.options |= C.CMARK_OPT_VALIDATE_UTF8
+	return p
 }
 
 // WithSmart maps to C.CMARK_OPT_SMART.
 // Converts straight quotes to curly, --- to em dashes, -- to en dashes.
-func (o *ParserOpts) WithSmart() *ParserOpts {
-	o.o |= C.CMARK_OPT_SMART
-	return o
+func (p *Parser) WithSmart() *Parser {
+	p.parser.options |= C.CMARK_OPT_SMART
+	return p
 }
 
 // free wraps cmark_parser_free
@@ -46,8 +38,8 @@ func (parser *Parser) free() { //go-cov:skip
 
 // NewParser wraps cmark_parser_new.
 // Creates a new parser object.
-func NewParser(opts *ParserOpts) *Parser {
-	parser := &Parser{parser: C.cmark_parser_new(opts.o)}
+func NewParser() *Parser {
+	parser := &Parser{parser: C.cmark_parser_new(C.CMARK_OPT_DEFAULT)}
 	runtime.SetFinalizer(parser, (*Parser).free)
 
 	return parser

--- a/pkg/cmark/parser_test.go
+++ b/pkg/cmark/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestParserAPI(t *testing.T) {
-	parser := NewParser(NewParserOpts())
+	parser := NewParser()
 	document := "# heading\n\nparagraph here\n"
 
 	scanner := bufio.NewScanner(strings.NewReader(document))
@@ -32,27 +32,27 @@ func TestParserAPI(t *testing.T) {
 func TestParserOpts(t *testing.T) {
 	for _, tc := range []struct {
 		content  string
-		opts     *ParserOpts
+		parser   *Parser
 		expected string
 	}{
 		{
 			"plain paragraph",
-			NewParserOpts(),
+			NewParser(),
 			"plain paragraph",
 		},
 		{
 			"bad UTF8: \xFF",
-			NewParserOpts().WithValidateUTF8(),
+			NewParser().WithValidateUTF8(),
 			"bad UTF8: �",
 		},
 		{
 			`text -- "with quotes" ---`,
-			NewParserOpts().WithSmart(),
+			NewParser().WithSmart(),
 			"text – “with quotes” —",
 		},
 	} {
 		t.Run(tc.content, func(t *testing.T) {
-			document := NewParser(tc.opts).ParseDocument(tc.content)
+			document := tc.parser.ParseDocument(tc.content)
 			parsedContent := document.FirstChild().FirstChild().GetLiteral()
 
 			require.NotNil(t, parsedContent)

--- a/pkg/cmark/render_test.go
+++ b/pkg/cmark/render_test.go
@@ -31,7 +31,7 @@ func TestRenderCommonMark(t *testing.T) {
 		},
 	} {
 		t.Run(desc, func(t *testing.T) {
-			document := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			document := NewParser().ParseDocument(tc.content)
 			require.Equal(t, tc.expected, RenderCommonMark(document, NewRenderOpts(), tc.width))
 		})
 	}
@@ -75,7 +75,7 @@ func TestRenderHTML(t *testing.T) {
 		},
 	} {
 		t.Run("", func(t *testing.T) {
-			root := NewParser(NewParserOpts()).ParseDocument(tc.content)
+			root := NewParser().ParseDocument(tc.content)
 
 			require.Equal(t, tc.expected, RenderHTML(root, tc.opts))
 		})


### PR DESCRIPTION
- Fix badge link

- cmark: add ParseDocument methond on parser

    I.e. copying across d7cf3ec8defe0ff786a03ccb462417e90eda3e4b

- Remove `ParserOpts`

    Add methods on the parser itself for this configuration instead, which I
    think is a nicer interface