### PR TITLE
Drop support for Go 1.19, add support for 1.21

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go_version: ["1.19", "1.20"]
+        go_version: ["1.20", "1.21"]
         os: [windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
With the release of Go 1.21 this is no longer supported[1]

> Each major Go release is supported until there are two newer major releases.

[1] https://go.dev/doc/devel/release#policy