### PR TITLE
Update extensions api

### DIFF
--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -45,7 +45,7 @@ func Example_extensions() {
 	CoreExtensionsEnsureRegistered()
 	document := "# My document\nWith ~~no~~ an extension\n"
 	parser := NewParser()
-	parser.AttachSyntaxExtension(FindSyntaxExtension("strikethrough"))
+	parser.AttachSyntaxExtension(FindSyntaxExtension(Strikethrough))
 
 	root := parser.ParseDocument(document)
 

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -44,8 +44,7 @@ func Example() {
 func Example_extensions() {
 	CoreExtensionsEnsureRegistered()
 	document := "# My document\nWith ~~no~~ an extension\n"
-	parser := NewParser()
-	parser.AttachSyntaxExtension(FindSyntaxExtension(Strikethrough))
+	parser := NewParser().WithSyntaxExtension(FindSyntaxExtension(Strikethrough))
 
 	root := parser.ParseDocument(document)
 

--- a/pkg/cmark-gfm/extension.go
+++ b/pkg/cmark-gfm/extension.go
@@ -11,7 +11,18 @@ package gfm
 import "C"
 
 import (
+	"fmt"
 	"unsafe"
+)
+
+type ExtensionName string
+
+const (
+	Table         ExtensionName = "table"
+	Strikethrough ExtensionName = "strikethrough"
+	AutoLink      ExtensionName = "autolink"
+	Tagfilter     ExtensionName = "tagfilter"
+	Tasklist      ExtensionName = "tasklist"
 )
 
 // CoreExtensionsEnsureRegistered wraps
@@ -41,14 +52,25 @@ type SyntaxExtensionList struct {
 }
 
 // FindSyntaxExtension wraps cmark_find_syntax_extension.
-// Finds the syntax extension with the given name, or 'nil' if not such extension is registered
-func FindSyntaxExtension(name string) *SyntaxExtension {
-	cs := C.CString(name)
+// Finds the syntax extension with the given name.
+// Panics if extensions have not been registered via
+// [CoreExtensionsEnsureRegistered]
+func FindSyntaxExtension(name ExtensionName) *SyntaxExtension {
+	cs := C.CString(string(name))
 	defer C.free(unsafe.Pointer(cs))
 
 	ext := C.cmark_find_syntax_extension(cs)
-	if ext == nil {
-		return nil
+	// testing this requires more complicated extension registering logic for
+	// testing, rather than just registering things at the global level
+	// and I'm not bothering wit that for the moment
+	if ext == nil { //go-cov:skip
+		panic(
+			fmt.Sprintf(
+				"Could not find extension %s. Has CoreExtensionsEnsureRegistered been called?",
+				name,
+			),
+		)
 	}
+
 	return &SyntaxExtension{ext: ext}
 }

--- a/pkg/cmark-gfm/extension_test.go
+++ b/pkg/cmark-gfm/extension_test.go
@@ -10,25 +10,25 @@ func TestExtensions(t *testing.T) {
 	for _, tc := range []struct {
 		content       string
 		renderOpts    *RenderOpts
-		extensionName string
+		extensionName ExtensionName
 		expected      string
 	}{
 		{
 			"|my table|\n|-|\n|blah|\n",
 			NewRenderOpts(),
-			"table",
+			Table,
 			"<table>\n<thead>\n<tr>\n<th>my table</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td>blah</td>\n</tr>\n</tbody>\n</table>\n",
 		},
 		{
 			"hello ~~world~~\n",
 			NewRenderOpts(),
-			"strikethrough",
+			Strikethrough,
 			"<p>hello <del>world</del></p>\n",
 		},
 		{
 			"visit https://www.github.com",
 			NewRenderOpts(),
-			"autolink",
+			AutoLink,
 			`<p>visit <a href="https://www.github.com">https://www.github.com</a></p>` + "\n",
 		},
 		{
@@ -36,20 +36,19 @@ func TestExtensions(t *testing.T) {
 			// cmark_render_html_with_mem(document, options, parser->syntax_extensions, mem);
 			"<script>alert(1)</script>\n",
 			NewRenderOpts().WithUnsafe(),
-			"tagfilter",
+			Tagfilter,
 			"&lt;script>alert(1)&lt;/script>\n",
 		},
 		{
 			"- [x] done\n- [ ] not done\n",
 			NewRenderOpts(),
-			"tasklist",
+			Tasklist,
 			"<ul>\n<li><input type=\"checkbox\" checked=\"\" disabled=\"\" /> done</li>\n<li><input type=\"checkbox\" disabled=\"\" /> not done</li>\n</ul>\n",
 		},
 	} {
-		t.Run(tc.extensionName, func(t *testing.T) {
+		t.Run(string(tc.extensionName), func(t *testing.T) {
 			parser := NewParser()
 			extension := FindSyntaxExtension(tc.extensionName)
-			require.NotNilf(t, extension, "Failed to find extension: %s", tc.extensionName)
 			parser.AttachSyntaxExtension(extension)
 			document := parser.ParseDocument(tc.content)
 
@@ -60,8 +59,4 @@ func TestExtensions(t *testing.T) {
 			)
 		})
 	}
-}
-
-func TestFindSyntaxExtensionNoExtension(t *testing.T) {
-	require.Nil(t, FindSyntaxExtension("not-a-registered-extension"))
 }

--- a/pkg/cmark-gfm/extension_test.go
+++ b/pkg/cmark-gfm/extension_test.go
@@ -47,9 +47,8 @@ func TestExtensions(t *testing.T) {
 		},
 	} {
 		t.Run(string(tc.extensionName), func(t *testing.T) {
-			parser := NewParser()
 			extension := FindSyntaxExtension(tc.extensionName)
-			parser.AttachSyntaxExtension(extension)
+			parser := NewParser().WithSyntaxExtension(extension)
 			document := parser.ParseDocument(tc.content)
 
 			require.Equal(

--- a/pkg/cmark-gfm/parser.go
+++ b/pkg/cmark-gfm/parser.go
@@ -39,6 +39,13 @@ func (p *Parser) WithFoonotes() *Parser {
 	return p
 }
 
+// WithSyntaxExtension wraps cmark_parser_attach_syntax_extension.
+// Attaches the given [SyntaxExtension] to the parser.
+func (p *Parser) WithSyntaxExtension(extension *SyntaxExtension) *Parser {
+	C.cmark_parser_attach_syntax_extension(p.parser, extension.ext)
+	return p
+}
+
 // free wraps cmark_parser_free
 func (parser *Parser) free() { //go-cov:skip
 	C.cmark_parser_free(parser.parser)
@@ -80,12 +87,6 @@ func (parser *Parser) ParseDocument(document string) *Node {
 	runtime.SetFinalizer(node, (*Node).free)
 
 	return node
-}
-
-// AttachSyntaxExtension wraps cmark_parser_attach_syntax_extension.
-// Attaches the given [SyntaxExtension] to the parser.
-func (parser *Parser) AttachSyntaxExtension(extension *SyntaxExtension) {
-	C.cmark_parser_attach_syntax_extension(parser.parser, extension.ext)
 }
 
 // SyntaxExtensions accesses cmark_parser.syntax_extensions.


### PR DESCRIPTION
- Avoid possibility of faults from `nil` extensions

    Add a type to control the names of available registers, not 100%
    foolproof but requires real effort to avoid if someone wants to.

    Add a panic if an extension can't be found, this should only ever occur
    if extensions haven't yet been registered

- Move syntax attaching to `With` func on parsers

    I find this just makes things more consistent