### PR TITLE
Avoid methods returning string pointers

### DIFF
--- a/cmd/cmark-ast/main.go
+++ b/cmd/cmark-ast/main.go
@@ -47,10 +47,10 @@ func dumpTree(node *cmark.Node, indentLevel int) {
 	}
 	fmt.Print(indentStr)
 
-	if nodeContent := node.GetLiteral(); nodeContent == nil {
+	if nodeContent := node.GetLiteral(); nodeContent == "" {
 		fmt.Printf("(%s)", node.GetTypeString())
 	} else {
-		fmt.Printf("(%s: '%s')", node.GetTypeString(), *nodeContent)
+		fmt.Printf("(%s: '%s')", node.GetTypeString(), nodeContent)
 	}
 
 	fmt.Println()

--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -26,10 +26,10 @@ func Example() {
 	fmt.Println(root.GetTypeString())
 	fmt.Println(heading.GetTypeString())
 	fmt.Println(headingContent.GetType() == NodeTypeText)
-	fmt.Println(*headingContent.GetLiteral())
+	fmt.Println(headingContent.GetLiteral())
 	fmt.Println(paragraph.GetTypeString())
 	fmt.Println(paragraphContent.GetType() == NodeTypeText)
-	fmt.Println(*paragraphContent.GetLiteral())
+	fmt.Println(paragraphContent.GetLiteral())
 
 	// Output:
 	// document

--- a/pkg/cmark-gfm/node.go
+++ b/pkg/cmark-gfm/node.go
@@ -101,8 +101,8 @@ func (node *Node) GetTypeString() string {
 // Returns a pointer to the string contents of 'node', or an empty
 // string if none is set. Returns nil if called on a
 // node that does not have string content.
-func (node *Node) GetLiteral() *string {
-	return stringOrNil(C.cmark_node_get_literal(node.node))
+func (node *Node) GetLiteral() string {
+	return C.GoString(C.cmark_node_get_literal(node.node))
 }
 
 // GetHeadingLevel wraps cmark_node_get_heading_level.
@@ -133,24 +133,24 @@ func (node *Node) IsTightList() bool {
 // GetFenceInfo wraps cmark_node_get_fence_info.
 // Returns the info string from a fenced code block.
 // Returns nil if called on a node that is not a code block
-func (node *Node) GetFenceInfo() *string {
-	return stringOrNil(C.cmark_node_get_fence_info(node.node))
+func (node *Node) GetFenceInfo() string {
+	return C.GoString(C.cmark_node_get_fence_info(node.node))
 }
 
 // GetUrl wraps cmark_node_get_url.
 // Returns the URL of a link or image 'node', or an empty string
 // if no URL is set.  Returns NULL if called on a node that is
 // not a link or image.
-func (node *Node) GetUrl() *string {
-	return stringOrNil(C.cmark_node_get_url(node.node))
+func (node *Node) GetUrl() string {
+	return C.GoString(C.cmark_node_get_url(node.node))
 }
 
 // GetTitle wraps cmark_node_get_title.
 // returns the title of a link or image 'node', or an empty string
 // if no URL is set. Returns nil if called on a node that is not a
 // link or image
-func (node *Node) GetTitle() *string {
-	return stringOrNil(C.cmark_node_get_title(node.node))
+func (node *Node) GetTitle() string {
+	return C.GoString(C.cmark_node_get_title(node.node))
 }
 
 // GetStartLine wraps cmark_node_get_start_line.
@@ -216,21 +216,6 @@ func (node *Node) ParentFootnoteDef() *Node {
 	return nodeOrNil(C.cmark_node_parent_footnote_def(node.node))
 }
 
-// some cmark functions like `cmark_node_get_url` reutrn a `char *` that will
-// be `NULL` if the relevant data can't be fetch (e.g. if the node doesn't
-// actually contain a URL) this preserves that behaviour
-// this could probably be somewhere shared, but https://github.com/golang/go/issues/13467
-func stringOrNil(s *C.char) *string {
-	if s == nil {
-		return nil
-	}
-
-	str := C.GoString(s)
-	return &str
-}
-
-// similar to above, though can't share because there's no single definition of
-// 'C.cmark_node' between the two libs
 func nodeOrNil(n *C.cmark_node) *Node {
 	if n == nil {
 		return nil

--- a/pkg/cmark-gfm/node_test.go
+++ b/pkg/cmark-gfm/node_test.go
@@ -58,7 +58,7 @@ func TestNodeType(t *testing.T) {
 func TestGetLiteralNoContent(t *testing.T) {
 	node := NewNode(NodeTypeNone)
 
-	assert.Nil(t, node.GetLiteral())
+	assert.Equal(t, "", node.GetLiteral())
 }
 
 func TestGetLiteralWithContent(t *testing.T) {
@@ -70,7 +70,7 @@ func TestGetLiteralWithContent(t *testing.T) {
 
 	headingText := heading.FirstChild()
 	require.NotNil(t, headingText)
-	assert.Equal(t, "heading", *headingText.GetLiteral())
+	assert.Equal(t, "heading", headingText.GetLiteral())
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
@@ -265,7 +265,7 @@ func TestGetFenceInfoNoInfo(t *testing.T) {
 	content := document.FirstChild()
 	require.NotNil(t, content)
 
-	require.Nil(t, content.GetFenceInfo())
+	require.Equal(t, "", content.GetFenceInfo())
 }
 
 func TestGetFenceInfo(t *testing.T) {
@@ -280,7 +280,7 @@ func TestGetFenceInfo(t *testing.T) {
 			document := NewParser().ParseDocument(tc.content)
 			fenceNode := document.FirstChild()
 
-			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
+			require.Equal(t, fenceNode.GetFenceInfo(), tc.expected)
 		})
 	}
 }
@@ -291,7 +291,7 @@ func TestGetUrlNoUrl(t *testing.T) {
 	content := document.FirstChild()
 	require.NotNil(t, content)
 
-	require.Nil(t, content.GetUrl())
+	require.Equal(t, "", content.GetUrl())
 }
 
 func TestGetURL(t *testing.T) {
@@ -309,7 +309,7 @@ func TestGetURL(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Equal(t, tc.expected, *linkNode.GetUrl())
+			require.Equal(t, tc.expected, linkNode.GetUrl())
 		})
 	}
 }
@@ -325,7 +325,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Nil(t, linkNode.GetTitle())
+			require.Equal(t, "", linkNode.GetTitle())
 		})
 	}
 }
@@ -345,7 +345,7 @@ func TestGetTitle(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Equal(t, tc.expected, *linkNode.GetTitle())
+			require.Equal(t, tc.expected, linkNode.GetTitle())
 		})
 	}
 }

--- a/pkg/cmark-gfm/parser_test.go
+++ b/pkg/cmark-gfm/parser_test.go
@@ -57,7 +57,7 @@ func TestParserOpts(t *testing.T) {
 			t.Log(RenderHTML(document, NewRenderOpts(), nil))
 
 			require.NotNil(t, parsedContent)
-			require.Equal(t, tc.expected, *parsedContent)
+			require.Equal(t, tc.expected, parsedContent)
 		})
 	}
 }

--- a/pkg/cmark/cmark_test.go
+++ b/pkg/cmark/cmark_test.go
@@ -17,10 +17,10 @@ func Example() {
 	fmt.Println(root.GetTypeString())
 	fmt.Println(heading.GetTypeString())
 	fmt.Println(headingContent.GetType() == NodeTypeText)
-	fmt.Println(*headingContent.GetLiteral())
+	fmt.Println(headingContent.GetLiteral())
 	fmt.Println(paragraph.GetTypeString())
 	fmt.Println(paragraphContent.GetType() == NodeTypeText)
-	fmt.Println(*paragraphContent.GetLiteral())
+	fmt.Println(paragraphContent.GetLiteral())
 
 	// Output:
 	// document

--- a/pkg/cmark/node.go
+++ b/pkg/cmark/node.go
@@ -101,8 +101,8 @@ func (node *Node) GetTypeString() string {
 // Returns a pointer to the string contents of 'node', or an empty
 // string if none is set. Returns nil if called on a
 // node that does not have string content.
-func (node *Node) GetLiteral() *string {
-	return stringOrNil(C.cmark_node_get_literal(node.node))
+func (node *Node) GetLiteral() string {
+	return C.GoString(C.cmark_node_get_literal(node.node))
 }
 
 // GetHeadingLevel wraps cmark_node_get_heading_level.
@@ -133,24 +133,24 @@ func (node *Node) IsTightList() bool {
 // GetFenceInfo wraps cmark_node_get_fence_info.
 // Returns the info string from a fenced code block. Returns nil if called on a
 // node that is not a code block
-func (node *Node) GetFenceInfo() *string {
-	return stringOrNil(C.cmark_node_get_fence_info(node.node))
+func (node *Node) GetFenceInfo() string {
+	return C.GoString(C.cmark_node_get_fence_info(node.node))
 }
 
 // GetUrl wraps cmark_node_get_url.
 // Returns the URL of a link or image 'node', or an empty string
 // if no URL is set.  Returns NULL if called on a node that is
 // not a link or image.
-func (node *Node) GetUrl() *string {
-	return stringOrNil(C.cmark_node_get_url(node.node))
+func (node *Node) GetUrl() string {
+	return C.GoString(C.cmark_node_get_url(node.node))
 }
 
 // GetTitle wraps cmark_node_get_title.
 // returns the title of a link or image 'node', or an empty string
 // if no URL is set. Returns nil if called on a node that is not a
 // link or image
-func (node *Node) GetTitle() *string {
-	return stringOrNil(C.cmark_node_get_title(node.node))
+func (node *Node) GetTitle() string {
+	return C.GoString(C.cmark_node_get_title(node.node))
 }
 
 // GetStartLine wraps cmark_node_get_start_line.
@@ -207,19 +207,6 @@ func (node *Node) FirstChild() *Node {
 // Returns the last child of 'node', or nil if 'node' has no children.
 func (node *Node) LastChild() *Node {
 	return nodeOrNil(C.cmark_node_last_child(node.node))
-}
-
-// some cmark functions like `cmark_node_get_url` reutrn a `char *` that will
-// be `NULL` if the relevant data can't be fetch (e.g. if the node doesn't
-// actually contain a URL) this preserves that behaviour
-// this could probably be somewhere shared, but https://github.com/golang/go/issues/13467
-func stringOrNil(s *C.char) *string {
-	if s == nil {
-		return nil
-	}
-
-	str := C.GoString(s)
-	return &str
 }
 
 func nodeOrNil(n *C.cmark_node) *Node {

--- a/pkg/cmark/node_test.go
+++ b/pkg/cmark/node_test.go
@@ -60,7 +60,7 @@ func TestNodeType(t *testing.T) {
 func TestGetLiteralNoContent(t *testing.T) {
 	node := NewNode(NodeTypeNone)
 
-	assert.Nil(t, node.GetLiteral())
+	assert.Equal(t, "", node.GetLiteral())
 }
 
 func TestGetLiteralWithContent(t *testing.T) {
@@ -72,7 +72,7 @@ func TestGetLiteralWithContent(t *testing.T) {
 
 	headingText := heading.FirstChild()
 	require.NotNil(t, headingText)
-	assert.Equal(t, "heading", *headingText.GetLiteral())
+	assert.Equal(t, "heading", headingText.GetLiteral())
 }
 
 func TestNodeFirstChildNoChild(t *testing.T) {
@@ -253,7 +253,7 @@ func TestGetFenceInfoNoInfo(t *testing.T) {
 	content := document.FirstChild()
 	require.NotNil(t, content)
 
-	require.Nil(t, content.GetFenceInfo())
+	require.Equal(t, "", content.GetFenceInfo())
 }
 
 func TestGetFenceInfo(t *testing.T) {
@@ -268,7 +268,7 @@ func TestGetFenceInfo(t *testing.T) {
 			document := NewParser().ParseDocument(tc.content)
 			fenceNode := document.FirstChild()
 
-			require.Equal(t, *fenceNode.GetFenceInfo(), tc.expected)
+			require.Equal(t, fenceNode.GetFenceInfo(), tc.expected)
 		})
 	}
 }
@@ -279,7 +279,7 @@ func TestGetUrlNoUrl(t *testing.T) {
 	content := document.FirstChild()
 	require.NotNil(t, content)
 
-	require.Nil(t, content.GetUrl())
+	require.Equal(t, "", content.GetUrl())
 }
 
 func TestGetURL(t *testing.T) {
@@ -297,7 +297,7 @@ func TestGetURL(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Equal(t, tc.expected, *linkNode.GetUrl())
+			require.Equal(t, tc.expected, linkNode.GetUrl())
 		})
 	}
 }
@@ -313,7 +313,7 @@ func TestGetTitleNoTitle(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Nil(t, linkNode.GetTitle())
+			require.Equal(t, "", linkNode.GetTitle())
 		})
 	}
 }
@@ -333,7 +333,7 @@ func TestGetTitle(t *testing.T) {
 
 			linkNode := document.FirstChild().FirstChild()
 
-			require.Equal(t, tc.expected, *linkNode.GetTitle())
+			require.Equal(t, tc.expected, linkNode.GetTitle())
 		})
 	}
 }

--- a/pkg/cmark/parser_test.go
+++ b/pkg/cmark/parser_test.go
@@ -56,7 +56,7 @@ func TestParserOpts(t *testing.T) {
 			parsedContent := document.FirstChild().FirstChild().GetLiteral()
 
 			require.NotNil(t, parsedContent)
-			require.Equal(t, tc.expected, *parsedContent)
+			require.Equal(t, tc.expected, parsedContent)
 		})
 	}
 }


### PR DESCRIPTION
This feels like an easy way to cause `nil` dereference panics. Even in my experience using these methods (e.g. [1]) I assume this will just be non-nil when I expect it to. So why not make it always non-nil and instead by non-empty when expected.

[1] https://gitlab.com/matthewhughes/common-changelog/-/blob/fff6c38da97d84b3ed23986319705ebea319bca8/pkg/parser.go#L79