### PR TITLE
Fix race condition in extension setup in tests

### DIFF
--- a/pkg/cmark-gfm/cmark_gfm_test.go
+++ b/pkg/cmark-gfm/cmark_gfm_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	// setup/teardown of extensions for entire test run
 	CoreExtensionsEnsureRegistered()
 	defer ReleasePlugins()
 
@@ -42,7 +43,9 @@ func Example() {
 }
 
 func Example_extensions() {
-	CoreExtensionsEnsureRegistered()
+	// commented out since these are handled separately in the test suite
+	// CoreExtensionsEnsureRegistered()
+	// defer ReleasePlugins()
 	document := "# My document\nWith ~~no~~ an extension\n"
 	parser := NewParser().WithSyntaxExtension(FindSyntaxExtension(Strikethrough))
 


### PR DESCRIPTION
There wasn't really an issue since the examples were always run after other tests, so calling `ReleasePlugins` in an example didn't impact any other tests. However, relying on this ordering is not a good idea.

Also add some comments explaining how extension setup is handled in tests